### PR TITLE
Makes abilities shared

### DIFF
--- a/Entities/Alchemy/AlchemicalInfuser.as
+++ b/Entities/Alchemy/AlchemicalInfuser.as
@@ -197,8 +197,10 @@ void onTick(CSprite@ this)
 	CSpriteLayer@ layer = this.getSpriteLayer("runes");
 	CBlob@ blob = this.getBlob();
 	CAlchemyTank@ tank = getTank(blob, 0);
+	array<CElementSetup> @elementlist = @getElementList();
 	SColor color(255, 0, 0, 0);
 	int id = -1;
+
 	if(tank !is null)
 		id = firstId(tank);
 	if(id != -1)
@@ -249,6 +251,7 @@ void onTick(CSprite@ this)
 void onTick(CBlob@ this)
 {
 	CAlchemyTank@ input = getTank(this, 0);
+	array<CElementSetup> @elementlist = @getElementList();
 	//CAlchemyTank@ inputr = getTank(this, "inputr");
 	//CAlchemyTank@ output = getTank(this, "output");
 	

--- a/Entities/Alchemy/AlchemicalMixer.as
+++ b/Entities/Alchemy/AlchemicalMixer.as
@@ -73,6 +73,7 @@ void onTick(CBlob@ this)
 	CAlchemyTank@ inputl = getTank(this, "Left Input");
 	CAlchemyTank@ inputr = getTank(this, "Right Input");
 	CAlchemyTank@ output = getTank(this, "Output");
+	array<CElementSetup> @elementlist = @getElementList();
 	
 	if(inputl !is null && inputr !is null && output !is null)
 	{

--- a/Entities/Alchemy/AlchemyCommon.as
+++ b/Entities/Alchemy/AlchemyCommon.as
@@ -2,7 +2,7 @@
 
 #include "ElementalCore.as";
 
-class CAlchemyTank
+shared class CAlchemyTank
 {
 	string name;
 	bool input;
@@ -36,7 +36,7 @@ class CAlchemyTank
 	
 }
 
-class CAlchemyTankController
+shared class CAlchemyTankController
 {
 	array<CAlchemyTank@> tanks;
 	
@@ -113,7 +113,7 @@ CAlchemyTank@ addTank(CBlob@ blob, string name, bool input, Vec2f offset)
 	return @controller.addTank(name, input, offset);
 }
 
-CAlchemyTank@ getTank(CBlob@ blob, string name)
+shared CAlchemyTank@ getTank(CBlob@ blob, string name)
 {
 	CAlchemyTankController@ controller;
 	blob.get("tankcontroller", @controller);
@@ -122,7 +122,7 @@ CAlchemyTank@ getTank(CBlob@ blob, string name)
 	return @controller.getTank(name);
 }
 
-CAlchemyTank@ getTank(CBlob@ blob, int id)
+shared CAlchemyTank@ getTank(CBlob@ blob, int id)
 {
 	CAlchemyTankController@ controller;
 	blob.get("tankcontroller", @controller);
@@ -131,7 +131,7 @@ CAlchemyTank@ getTank(CBlob@ blob, int id)
 	return @controller.getTank(id);
 }
 
-u8 getTankID(CBlob@ blob, string name)
+shared u8 getTankID(CBlob@ blob, string name)
 {
 	CAlchemyTankController@ controller;
 	blob.get("tankcontroller", @controller);
@@ -140,7 +140,7 @@ u8 getTankID(CBlob@ blob, string name)
 	return controller.getTankID(name);
 }
 
-u8 getTankID(CBlob@ blob, CAlchemyTank@ tank)
+shared u8 getTankID(CBlob@ blob, CAlchemyTank@ tank)
 {
 	CAlchemyTankController@ controller;
 	blob.get("tankcontroller", @controller);
@@ -159,9 +159,9 @@ void addToTank(CAlchemyTank@ tank, array<int>@ elements)
 
 void addToTank(CAlchemyTank@ tank, string element, int count)
 {
-	for (int i = 0; i < elementlist.length; i++)
+	for (int i = 0; i < getElementList().length; i++)
 	{
-		if(elementlist[i].name == element)
+		if(getElementList()[i].name == element)
 		{
 			tank.storage.elements[i] += count;
 			return;
@@ -197,7 +197,7 @@ int storageLeft(CAlchemyTank@ tank, int id)
 	return Maths::Max(tank.maxelements - output, 0);
 }
 
-int firstId(CAlchemyTank@ tank)
+shared int firstId(CAlchemyTank@ tank)
 {
 	for (int i = 0; i < tank.storage.elements.length; i++)
 	{
@@ -246,7 +246,7 @@ void transferBlacklist(CAlchemyTank@ input, CAlchemyTank@ output, int amount, ar
 		bool skip = false;
 		for (int j = 0; j < blacklist.length; j++)
 		{
-			if(elementlist[i].name == blacklist[j])
+			if(getElementList()[i].name == blacklist[j])
 			{
 				skip = true;
 				break;
@@ -316,7 +316,7 @@ void transferOnly(CAlchemyTank@ input, CAlchemyTank@ output, int amount, int onl
 		transferSimple(input, output, amount);
 		return;
 	}
-	string onlyname = elementlist[only].name;
+	string onlyname = getElementList()[only].name;
 	transferOnly(input, output, amount, onlyname);
 }
 
@@ -338,7 +338,7 @@ SColor getAverageElementColor(CAlchemyTank@ tank)
 	for (int i = 0; i < tank.storage.elements.length; i++)
 	{
 		float ratio = float(tank.storage.elements[i]) / float(tank.maxelements);
-		SColor elecol = elementlist[i].color;
+		SColor elecol = getElementList()[i].color;
 		output.set(255, output.getRed() + elecol.getRed() * ratio, output.getGreen() + elecol.getGreen() * ratio, output.getBlue() + elecol.getBlue() * ratio);
 	}
 	return output;

--- a/Entities/Alchemy/AlchemyCore.as
+++ b/Entities/Alchemy/AlchemyCore.as
@@ -33,7 +33,8 @@ void onInit(CBlob@ this)
 	
 	//Can be changed in the blob's own scripts
 	this.set_u16("transferrate", 1);
-	
+
+	array<CElementSetup> @elementlist = @getElementList();
 	for(int i = 0; i < elementlist.length; i++)
 	{
 		AddIconToken("$element_" + elementlist[i].name + "$", "ElementIcons.png", Vec2f(16, 16), i);
@@ -68,6 +69,7 @@ void onRender(CSprite@ this)
 void onTick(CSprite@ this)
 {
 	CBlob@ blob = this.getBlob();
+	array<CElementSetup> @elementlist = @getElementList();
 	
 	CAlchemyTankController@ controller = getTankController(blob);
 	if(controller is null)
@@ -141,6 +143,7 @@ void onTick(CBlob@ this)
 {
 	manageConnectSys(this);
 	CAlchemyTankController@ controller = getTankController(this);
+	array<CElementSetup> @elementlist = @getElementList();
 	
 	if(controller is null)
 		return;

--- a/Entities/Alchemy/AlchemyFocusBehavior.as
+++ b/Entities/Alchemy/AlchemyFocusBehavior.as
@@ -36,21 +36,21 @@ funcdef float sprayProto(int, float, float, float, CBlob@, CBlob@);
 
 //PAD FOCUS BEHAVIOR
 
-float padBlank(CBlob@ blob, int power, CBlob@ pad){return 1;}
+shared float padBlank(CBlob@ blob, int power, CBlob@ pad){return 1;}
 
-float padAer(CBlob@ blob, int power, CBlob@ pad)
+shared float padAer(CBlob@ blob, int power, CBlob@ pad)
 {
 	bool blobmovingleft = pad.isFacingLeft();
 	
 	blob.setVelocity(Vec2f(blobmovingleft ? 3 : -3, -3) * power + blob.getVelocity());
 	
-	applyFxLightFall(blob, power * 30, power);
+	FxLightFall::apply(blob, power * 30, power);
 	
 	if(getNet().isClient())
 	{
 		for (int i = 0; i < 20; i++)
 		{
-			CRenderParticleString newpart(1, false, false, 30, 1, elementlist[4].color, true, 0, 5);
+			CRenderParticleString newpart(1, false, false, 30, 1, getElementList()[4].color, true, 0, 5);
 			newpart.velocity = Vec2f((float(XORRandom(1000) - 500) / 1000.0) + (pad.isFacingLeft() ? 2 : -2), (XORRandom(1000) / 1000.0) * -2 + -3) * 5;
 			newpart.position = pad.getPosition() + Vec2f(float(XORRandom(1000) / 1000.0 - 0.5) * 32, float(XORRandom(1000) / 1000.0 - 0.5) * 4);
 			addParticleToList(newpart);
@@ -59,14 +59,14 @@ float padAer(CBlob@ blob, int power, CBlob@ pad)
 	return 1;
 }
 
-float padLife(CBlob@ blob, int power, CBlob@ pad)
+shared float padLife(CBlob@ blob, int power, CBlob@ pad)
 {
 	blob.server_SetHealth(Maths::Min(blob.getHealth() + float(power) * 0.2, blob.getInitialHealth() * 2));
 	if(getNet().isClient())
 	{
 		for (int i = 0; i < 20; i++)
 		{
-			CRenderParticleString newpart(1, false, false, 10, 0, elementlist[1].color, true, 0, 5);
+			CRenderParticleString newpart(1, false, false, 10, 0, getElementList()[1].color, true, 0, 5);
 			float temprot = XORRandom(1000) / 500.0 * Maths::Pi;
 			newpart.velocity = Vec2f(Maths::Cos(temprot + Maths::Pi), Maths::Sin(temprot + Maths::Pi)) * 3;
 			newpart.position = blob.getPosition() + Vec2f(Maths::Cos(temprot), Maths::Sin(temprot)) * 30;
@@ -76,15 +76,15 @@ float padLife(CBlob@ blob, int power, CBlob@ pad)
 	return 1;
 }
 
-float padEcto(CBlob@ blob, int power, CBlob@ pad)
+shared float padEcto(CBlob@ blob, int power, CBlob@ pad)
 {
 	//900 = 30 seconds, should be a good amount?
-	applyFxLowGrav(blob, power * 180 * 5, Maths::Ceil(float(power) / 5.0));
+	FxLowGrav::apply(blob, power * 180 * 5, Maths::Ceil(float(power) / 5.0));
 	if(getNet().isClient())
 	{
 		for (int i = 0; i < 20; i++)
 		{
-			CRenderParticleString newpart(1, false, false, 10, 0.25, elementlist[0].color, true, 0, 5);
+			CRenderParticleString newpart(1, false, false, 10, 0.25, getElementList()[0].color, true, 0, 5);
 			newpart.velocity = Vec2f(float(XORRandom(1000) - 500) / 1000.0, (XORRandom(1000) / 1000.0) * -2 + -3);
 			newpart.position = pad.getPosition() + Vec2f(float(XORRandom(1000) / 1000.0 - 0.5) * 32, float(XORRandom(1000) / 1000.0 - 0.5) * 4);
 			addParticleToList(newpart);
@@ -93,7 +93,7 @@ float padEcto(CBlob@ blob, int power, CBlob@ pad)
 	return 1;
 }
 
-float padForce(CBlob@ blob, int power, CBlob@ pad)
+shared float padForce(CBlob@ blob, int power, CBlob@ pad)
 {
 	bool blobmovingleft = pad.isFacingLeft();
 	
@@ -102,7 +102,7 @@ float padForce(CBlob@ blob, int power, CBlob@ pad)
 	{
 		for (int i = 0; i < 20; i++)
 		{
-			CRenderParticleString newpart(1, false, false, 30, 0.1, elementlist[3].color, true, 0, 5);
+			CRenderParticleString newpart(1, false, false, 30, 0.1, getElementList()[3].color, true, 0, 5);
 			newpart.velocity = Vec2f((float(XORRandom(1000) - 500) / 1000.0) + (pad.isFacingLeft() ? 2 : -2), (XORRandom(1000) / 1000.0) * -0.2 + -0.3) * 7;
 			newpart.position = pad.getPosition() + Vec2f(float(XORRandom(1000) / 1000.0 - 0.5) * 32, float(XORRandom(1000) / 1000.0 - 0.5) * 4);
 			addParticleToList(newpart);
@@ -111,14 +111,14 @@ float padForce(CBlob@ blob, int power, CBlob@ pad)
 	return 1;
 }
 
-float padIgnis(CBlob@ blob, int power, CBlob@ pad)
+shared float padIgnis(CBlob@ blob, int power, CBlob@ pad)
 {
 	pad.server_Hit(blob, blob.getPosition(), Vec2f_zero, power * 0.1, Hitters::fire);
 	if(getNet().isClient())
 	{
 		for (int i = 0; i < 20; i++)
 		{
-			CRenderParticleString newpart(1, false, false, 10, 0, elementlist[5].color, true, 0, 5);
+			CRenderParticleString newpart(1, false, false, 10, 0, getElementList()[5].color, true, 0, 5);
 			newpart.velocity = Vec2f(float(XORRandom(1000) - 500) / 1000.0, (XORRandom(1000) / 1000.0) * -2 + -3);
 			newpart.position = pad.getPosition() + Vec2f(float(XORRandom(1000) / 1000.0 - 0.5) * 32, float(XORRandom(1000) / 1000.0 - 0.5) * 4);
 			addParticleToList(newpart);
@@ -127,14 +127,14 @@ float padIgnis(CBlob@ blob, int power, CBlob@ pad)
 	return 1;
 }
 
-float padTerra(CBlob@ blob, int power, CBlob@ pad)
+shared float padTerra(CBlob@ blob, int power, CBlob@ pad)
 {
-	applyFxDamageReduce(blob, power * 180 * 5, Maths::Ceil(float(power) / 5.0));
+	FxDamageReduce::apply(blob, power * 180 * 5, Maths::Ceil(float(power) / 5.0));
 	if(getNet().isClient())
 	{
 		for (int i = 0; i < 20; i++)
 		{
-			CRenderParticleString newpart(1, false, false, 10, 0, elementlist[6].color, true, 0, 5);
+			CRenderParticleString newpart(1, false, false, 10, 0, getElementList()[6].color, true, 0, 5);
 			float temprot = XORRandom(1000) / 500.0 * Maths::Pi;
 			newpart.velocity = Vec2f(Maths::Cos(temprot + Maths::Pi), Maths::Sin(temprot + Maths::Pi)) * 3;
 			newpart.position = blob.getPosition() + Vec2f(Maths::Cos(temprot), Maths::Sin(temprot)) * 30;
@@ -144,14 +144,14 @@ float padTerra(CBlob@ blob, int power, CBlob@ pad)
 	return 1;
 }
 
-float padNatura(CBlob@ blob, int power, CBlob@ pad)//Nature gives regen? 100% not a ros ripoff
+shared float padNatura(CBlob@ blob, int power, CBlob@ pad)//Nature gives regen? 100% not a ros ripoff
 {
-	applyFxRegen(blob, power * 180 * 2, Maths::Ceil(float(power) / 5.0));
+	FxRegen::apply(blob, power * 180 * 2, Maths::Ceil(float(power) / 5.0));
 	if(getNet().isClient())
 	{
 		for (int i = 0; i < 20; i++)
 		{
-			CRenderParticleString newpart(1, false, false, 10, 0, elementlist[2].color, true, 0, 5);
+			CRenderParticleString newpart(1, false, false, 10, 0, getElementList()[2].color, true, 0, 5);
 			float temprot = XORRandom(1000) / 500.0 * Maths::Pi;
 			newpart.velocity = Vec2f(Maths::Cos(temprot + Maths::Pi), Maths::Sin(temprot + Maths::Pi)) * 3;
 			newpart.position = blob.getPosition() + Vec2f(Maths::Cos(temprot), Maths::Sin(temprot)) * 30;
@@ -161,14 +161,14 @@ float padNatura(CBlob@ blob, int power, CBlob@ pad)//Nature gives regen? 100% no
 	return 1;
 }
 
-float padEntropy(CBlob@ blob, int power, CBlob@ pad)
+shared float padEntropy(CBlob@ blob, int power, CBlob@ pad)
 {
 	pad.server_Hit(blob, blob.getPosition(), Vec2f_zero, power * 0.4, Hitters::spikes);
 	if(getNet().isClient())
 	{
 		for (int i = 0; i < 20; i++)
 		{
-			CRenderParticleString newpart(1, false, false, 10, 0, elementlist[8].color, true, 0, 5);
+			CRenderParticleString newpart(1, false, false, 10, 0, getElementList()[8].color, true, 0, 5);
 			float temprot = XORRandom(1000) / 500.0 * Maths::Pi;
 			newpart.velocity = Vec2f(Maths::Cos(temprot + Maths::Pi), Maths::Sin(temprot + Maths::Pi)) * 3;
 			newpart.position = blob.getPosition() + Vec2f(Maths::Cos(temprot), Maths::Sin(temprot)) * 30;
@@ -178,15 +178,15 @@ float padEntropy(CBlob@ blob, int power, CBlob@ pad)
 	return 1;
 }
 
-float padOrder(CBlob@ blob, int power, CBlob@ pad)
+shared float padOrder(CBlob@ blob, int power, CBlob@ pad)
 {
 	blob.setVelocity(Vec2f(0, -0.5) * power + blob.getVelocity());
-	applyFxLowGrav(blob, power * 30, 100);
+	FxLowGrav::apply(blob, power * 30, 100);
 	if(getNet().isClient())
 	{
 		for (int i = 0; i < 20; i++)
 		{
-			CRenderParticleString newpart(1, false, false, 100, 0, elementlist[7].color, true, 0, 5);
+			CRenderParticleString newpart(1, false, false, 100, 0, getElementList()[7].color, true, 0, 5);
 			newpart.velocity = Vec2f(float(XORRandom(1000) - 500) / 1000.0, (XORRandom(1000) / 1000.0) * -0.3 + -2.5);
 			newpart.position = pad.getPosition() + Vec2f(float(XORRandom(1000) / 1000.0 - 0.5) * 32, float(XORRandom(1000) / 1000.0 - 0.5) * 4);
 			addParticleToList(newpart);
@@ -196,14 +196,14 @@ float padOrder(CBlob@ blob, int power, CBlob@ pad)
 }
 
 
-float padAqua(CBlob@ blob, int power, CBlob@ pad)
+shared float padAqua(CBlob@ blob, int power, CBlob@ pad)
 {
 	pad.server_Hit(blob, blob.getPosition(), Vec2f_zero, 0, Hitters::water_stun_force);
 	if(getNet().isClient())
 	{
 		for (int i = 0; i < 20; i++)
 		{
-			CRenderParticleString newpart(1, false, false, 10, 0.5, elementlist[9].color, true, 0, 5);
+			CRenderParticleString newpart(1, false, false, 10, 0.5, getElementList()[9].color, true, 0, 5);
 			newpart.velocity = Vec2f(float(XORRandom(1000) - 500) / 1000.0, (XORRandom(1000) / 1000.0) * -2 + -3);
 			newpart.position = pad.getPosition() + Vec2f(float(XORRandom(1000) / 1000.0 - 0.5) * 32, float(XORRandom(1000) / 1000.0 - 0.5) * 4);
 			addParticleToList(newpart);
@@ -212,15 +212,15 @@ float padAqua(CBlob@ blob, int power, CBlob@ pad)
 	return 1;
 }
 
-float padCorruption(CBlob@ blob, int power, CBlob@ pad)
+shared float padCorruption(CBlob@ blob, int power, CBlob@ pad)
 {
 	//blob.setVelocity(Vec2f(0, -0.5) * power + blob.getVelocity());
-	applyFxCorrupt(blob, 180 * power * 5, power * 0.4);
+	FxCorrupt::apply(blob, 180 * power * 5, power * 0.4);
 	if(getNet().isClient())
 	{
 		for (int i = 0; i < 20; i++)
 		{
-			CRenderParticleString newpart(1, false, false, 10, 0.5, elementlist[10].color, true, 0, 5);
+			CRenderParticleString newpart(1, false, false, 10, 0.5, getElementList()[10].color, true, 0, 5);
 			newpart.velocity = Vec2f(float(XORRandom(1000) - 500) / 1000.0, (XORRandom(1000) / 1000.0) * -0.3 + -2.5);
 			newpart.position = pad.getPosition() + Vec2f(float(XORRandom(1000) / 1000.0 - 0.5) * 32, float(XORRandom(1000) / 1000.0 - 0.5) * 4);
 			addParticleToList(newpart);
@@ -229,15 +229,15 @@ float padCorruption(CBlob@ blob, int power, CBlob@ pad)
 	return 1;
 }
 
-float padPurity(CBlob@ blob, int power, CBlob@ pad)
+shared float padPurity(CBlob@ blob, int power, CBlob@ pad)
 {
 	//blob.setVelocity(Vec2f(0, -0.5) * power + blob.getVelocity());
-	applyFxPure(blob, 180 * power * 10, power * 0.4);
+	FxPure::apply(blob, 180 * power * 10, power * 0.4);
 	if(getNet().isClient())
 	{
 		for (int i = 0; i < 20; i++)
 		{
-			CRenderParticleString newpart(1, false, false, 10, 0.5, elementlist[11].color, true, 0, 5);
+			CRenderParticleString newpart(1, false, false, 10, 0.5, getElementList()[11].color, true, 0, 5);
 			newpart.velocity = Vec2f(float(XORRandom(1000) - 500) / 1000.0, (XORRandom(1000) / 1000.0) * -0.3 + -2.5);
 			newpart.position = pad.getPosition() + Vec2f(float(XORRandom(1000) / 1000.0 - 0.5) * 32, float(XORRandom(1000) / 1000.0 - 0.5) * 4);
 			addParticleToList(newpart);
@@ -246,15 +246,15 @@ float padPurity(CBlob@ blob, int power, CBlob@ pad)
 	return 1;
 }
 
-float padHoly(CBlob@ blob, int power, CBlob@ pad)
+shared float padHoly(CBlob@ blob, int power, CBlob@ pad)
 {
 	//blob.setVelocity(Vec2f(0, -0.5) * power + blob.getVelocity());
-	applyFxHoly(blob, 180 * power * 5, power);
+	FxHoly::apply(blob, 180 * power * 5, power);
 	if(getNet().isClient())
 	{
 		for (int i = 0; i < 20; i++)
 		{
-			CRenderParticleString newpart(1, false, false, 10, 0.5, elementlist[13].color, true, 0, 5);
+			CRenderParticleString newpart(1, false, false, 10, 0.5, getElementList()[13].color, true, 0, 5);
 			newpart.velocity = Vec2f(float(XORRandom(1000) - 500) / 1000.0, (XORRandom(1000) / 1000.0) * -0.3 + -2.5);
 			newpart.position = pad.getPosition() + Vec2f(float(XORRandom(1000) / 1000.0 - 0.5) * 32, float(XORRandom(1000) / 1000.0 - 0.5) * 4);
 			addParticleToList(newpart);
@@ -263,15 +263,15 @@ float padHoly(CBlob@ blob, int power, CBlob@ pad)
 	return 1;
 }
 
-float padUnholy(CBlob@ blob, int power, CBlob@ pad)
+shared float padUnholy(CBlob@ blob, int power, CBlob@ pad)
 {
 	//blob.setVelocity(Vec2f(0, -0.5) * power + blob.getVelocity());
-	applyFxUnholy(blob, 180 * power * 5, power);
+	FxUnholy::apply(blob, 180 * power * 5, power);
 	if(getNet().isClient())
 	{
 		for (int i = 0; i < 20; i++)
 		{
-			CRenderParticleString newpart(1, false, false, 10, 0.5, elementlist[12].color, true, 0, 5);
+			CRenderParticleString newpart(1, false, false, 10, 0.5, getElementList()[12].color, true, 0, 5);
 			newpart.velocity = Vec2f(float(XORRandom(1000) - 500) / 1000.0, (XORRandom(1000) / 1000.0) * -0.3 + -2.5);
 			newpart.position = pad.getPosition() + Vec2f(float(XORRandom(1000) / 1000.0 - 0.5) * 32, float(XORRandom(1000) / 1000.0 - 0.5) * 4);
 			addParticleToList(newpart);
@@ -285,9 +285,9 @@ float padUnholy(CBlob@ blob, int power, CBlob@ pad)
 
 
 
-float wardBlank(float radius, int power, CBlob@ ward){return 0;}
+shared float wardBlank(float radius, int power, CBlob@ ward){return 0;}
 
-float wardForce(float radius, int power, CBlob@ ward)
+shared float wardForce(float radius, int power, CBlob@ ward)
 {
 	CBlob@[] blobs;
 	CMap@ map = getMap();
@@ -314,7 +314,7 @@ float wardForce(float radius, int power, CBlob@ ward)
 }
 
 
-float wardNatura(float radius, int power, CBlob@ ward)
+shared float wardNatura(float radius, int power, CBlob@ ward)
 {
 	CBlob@[] blobs;
 	CMap@ map = getMap();
@@ -351,7 +351,7 @@ float wardNatura(float radius, int power, CBlob@ ward)
 	return 0.1;
 }
 
-float wardLife(float radius, int power, CBlob@ ward)
+shared float wardLife(float radius, int power, CBlob@ ward)
 {
 	CBlob@[] blobs;
 	CMap@ map = getMap();
@@ -374,7 +374,7 @@ float wardLife(float radius, int power, CBlob@ ward)
 }
 
 
-float wardAer(float radius, int power, CBlob@ ward)
+shared float wardAer(float radius, int power, CBlob@ ward)
 {
 	CBlob@[] blobs;
 	CMap@ map = getMap();
@@ -399,7 +399,7 @@ float wardAer(float radius, int power, CBlob@ ward)
 	return 0.1;
 }
 
-float wardEcto(float radius, int power, CBlob@ ward)
+shared float wardEcto(float radius, int power, CBlob@ ward)
 {
 	CBlob@[] blobs;
 	CMap@ map = getMap();
@@ -413,8 +413,8 @@ float wardEcto(float radius, int power, CBlob@ ward)
 				activated = true;
 				if(getGameTime() % 3 == 0)
 				{
-					applyFxGhostlike(blobs[i], 2 * power, 1);
-					applyFxLowGrav(blobs[i], 2 * power, 100);
+					FxGhostlike::apply(blobs[i], 2 * power, 1);
+					FxLowGrav::apply(blobs[i], 2 * power, 100);
 				}
 			}
 		}
@@ -425,7 +425,7 @@ float wardEcto(float radius, int power, CBlob@ ward)
 }
 
 
-float wardIgnis(float radius, int power, CBlob@ ward)
+shared float wardIgnis(float radius, int power, CBlob@ ward)
 {
 	CMap@ map = getMap();
 	bool activated = false;
@@ -462,7 +462,7 @@ float wardIgnis(float radius, int power, CBlob@ ward)
 }
 
 //Slowly regenerates stone and dirt
-float wardTerra(float radius, int power, CBlob@ ward) 
+shared float wardTerra(float radius, int power, CBlob@ ward) 
 {
 	Random rando(XORRandom(0x7FFFFFFF));
 	bool activated = false;
@@ -508,7 +508,7 @@ float wardTerra(float radius, int power, CBlob@ ward)
 	return 0.1;
 }
 
-float wardOrder(float radius, int power, CBlob@ ward)
+shared float wardOrder(float radius, int power, CBlob@ ward)
 {
 	Random rando(XORRandom(0x7FFFFFFF));
 	bool activated = false;
@@ -527,7 +527,7 @@ float wardOrder(float radius, int power, CBlob@ ward)
 	return 0.1;
 }
 
-float wardEntropy(float radius, int power, CBlob@ ward) //probobly broken code :D 
+shared float wardEntropy(float radius, int power, CBlob@ ward) //probobly broken code :D 
 //also feel free to change idea mainly just wanted to see what it would look like
 //Just fixed it up a bit, dun worri, is gud ward
 {
@@ -548,7 +548,7 @@ float wardEntropy(float radius, int power, CBlob@ ward) //probobly broken code :
 	return 0.1;
 }
 
-float wardAqua(float radius, int power, CBlob@ ward)
+shared float wardAqua(float radius, int power, CBlob@ ward)
 {
 	CMap@ map = getMap();
 	Random rando(XORRandom(0x7FFFFFFF));
@@ -623,7 +623,7 @@ float wardAqua(float radius, int power, CBlob@ ward)
 	return 0.1;
 }
 
-float wardCorruption(float radius, int power, CBlob@ ward) 
+shared float wardCorruption(float radius, int power, CBlob@ ward) 
 {
 	if(getGameTime() % (150 / power) != 0)
 		return 1;
@@ -637,7 +637,7 @@ float wardCorruption(float radius, int power, CBlob@ ward)
 	return 1;
 }
 
-float wardPurity(float radius, int power, CBlob@ ward) 
+shared float wardPurity(float radius, int power, CBlob@ ward) 
 {
 	Random rando(XORRandom(0x7FFFFFFF));
 	CMap@ map = getMap();
@@ -654,7 +654,7 @@ float wardPurity(float radius, int power, CBlob@ ward)
 	return 0.1;
 }
 
-float wardUnholy(float radius, int power, CBlob@ ward)
+shared float wardUnholy(float radius, int power, CBlob@ ward)
 {
 	CMap@ map = getMap();
 	Random rando(XORRandom(0x7FFFFFFF));
@@ -680,7 +680,7 @@ float wardUnholy(float radius, int power, CBlob@ ward)
 //BINDER BEHVAIOR BEYOND HERE
 
 
-void bindBlank(CBlob@ blob, int power, CBlob@ bind){}
+shared void bindBlank(CBlob@ blob, int power, CBlob@ bind){}
 /*
 void bindAer(CBlob@ blob, int power, CBlob@ bind)
 {
@@ -689,17 +689,17 @@ void bindAer(CBlob@ blob, int power, CBlob@ bind)
 	blob.setVelocity(Vec2f(blobmovingleft ? 3 : -3, -3) * power + blob.getVelocity());
 }
 */
-void bindLife(CBlob@ blob, int power, CBlob@ bind)
+shared void bindLife(CBlob@ blob, int power, CBlob@ bind)
 {
 	if(getGameTime() % 30 == 0)
 		blob.server_SetHealth(Maths::Min(blob.getHealth() + float(power) * 0.05, blob.getInitialHealth() * 2));
 }
 
-void bindEcto(CBlob@ blob, int power, CBlob@ bind)
+shared void bindEcto(CBlob@ blob, int power, CBlob@ bind)
 {
 	//900 = 30 seconds, should be a good amount?
 	if(getGameTime() % 30 == 0)
-		applyFxLowGrav(blob, power * 10, Maths::Ceil(float(power) / 5.0));
+		FxLowGrav::apply(blob, power * 10, Maths::Ceil(float(power) / 5.0));
 }
 /*
 void bindForce(CBlob@ blob, int power, CBlob@ bind)
@@ -709,16 +709,16 @@ void bindForce(CBlob@ blob, int power, CBlob@ bind)
 	blob.setVelocity(Vec2f(blobmovingleft ? 5 : -5, 0) * power + blob.getVelocity());
 }
 */
-void bindIgnis(CBlob@ blob, int power, CBlob@ bind)
+shared void bindIgnis(CBlob@ blob, int power, CBlob@ bind)
 {
 	if(getGameTime() % 30 == 0)
 		bind.server_Hit(blob, blob.getPosition(), Vec2f_zero, power * 0.1, Hitters::fire);
 }
 
-void bindTerra(CBlob@ blob, int power, CBlob@ bind)
+shared void bindTerra(CBlob@ blob, int power, CBlob@ bind)
 {
 	if(getGameTime() % 30 == 0)
-		applyFxDamageReduce(blob, power * 10, Maths::Ceil(float(power) / 5.0));
+		FxDamageReduce::apply(blob, power * 10, Maths::Ceil(float(power) / 5.0));
 }
 /*
 void bindEntropy(CBlob@ blob, int power, CBlob@ bind)
@@ -726,11 +726,11 @@ void bindEntropy(CBlob@ blob, int power, CBlob@ bind)
 	bind.server_Hit(blob, blob.getPosition(), Vec2f_zero, power * 0.4, Hitters::spikes);
 }
 */
-void bindOrder(CBlob@ blob, int power, CBlob@ bind)
+shared void bindOrder(CBlob@ blob, int power, CBlob@ bind)
 {
 	blob.setVelocity(Vec2f(0, -0.02) * power + blob.getVelocity());
 	if(getGameTime() % 30 == 0)
-		applyFxLowGrav(blob, power * 10, 100);
+		FxLowGrav::apply(blob, power * 10, 100);
 }
 
 /*
@@ -747,9 +747,9 @@ void bindAqua(CBlob@ blob, int power, CBlob@ bind)
 //Spray Particle Scale
 const float sprayPSC = 1.5;
 
-float sprayBlank(int power, float aimdir, float spread, float range, CBlob@ spray, CBlob@ user){return 0;}
+shared float sprayBlank(int power, float aimdir, float spread, float range, CBlob@ spray, CBlob@ user){return 0;}
 
-float sprayForce(int power, float aimdir, float spread, float range, CBlob@ spray, CBlob@ user)
+shared float sprayForce(int power, float aimdir, float spread, float range, CBlob@ spray, CBlob@ user)
 {
 	HitInfo@[] list;
 	CMap@ map = getMap();
@@ -771,7 +771,7 @@ float sprayForce(int power, float aimdir, float spread, float range, CBlob@ spra
 	{
 		for (int i = 0; i < 8; i++)
 		{
-			CRenderParticleArrow newpart(sprayPSC, false, false, 4, 0, elementlist[3].color, true, 0);
+			CRenderParticleArrow newpart(sprayPSC, false, false, 4, 0, getElementList()[3].color, true, 0);
 			newpart.velocity = Vec2f(1, 0).RotateBy(aimdir + (XORRandom(1000) / 500.0 - 1.0) * (spread / 2)) * range * (XORRandom(1000) / 2000.0 + 0.5) / 8;
 			newpart.position = user.getPosition() /*+ Vec2f(float(XORRandom(1000) / 1000.0 - 0.5) * 16, float(XORRandom(1000) / 1000.0 - 0.5) * 16)*/;
 			addParticleToList(newpart);
@@ -780,7 +780,7 @@ float sprayForce(int power, float aimdir, float spread, float range, CBlob@ spra
 	return 1;
 }
 
-float sprayEcto(int power, float aimdir, float spread, float range, CBlob@ spray, CBlob@ user)
+shared float sprayEcto(int power, float aimdir, float spread, float range, CBlob@ spray, CBlob@ user)
 {//This one is pretty lame but eh, good eneough
 	HitInfo@[] list;
 	CMap@ map = getMap();
@@ -808,7 +808,7 @@ float sprayEcto(int power, float aimdir, float spread, float range, CBlob@ spray
 	{
 		for (int i = 0; i < 8; i++)
 		{
-			CRenderParticleArrow newpart(sprayPSC, false, false, 4, 0, elementlist[0].color, true, 0);
+			CRenderParticleArrow newpart(sprayPSC, false, false, 4, 0, getElementList()[0].color, true, 0);
 			newpart.velocity = Vec2f(1, 0).RotateBy(aimdir + (XORRandom(1000) / 500.0 - 1.0) * (spread / 2)) * range * (XORRandom(1000) / 2000.0 + 0.5) / 8;
 			newpart.position = user.getPosition() /*+ Vec2f(float(XORRandom(1000) / 1000.0 - 0.5) * 16, float(XORRandom(1000) / 1000.0 - 0.5) * 16)*/;
 			addParticleToList(newpart);
@@ -817,13 +817,13 @@ float sprayEcto(int power, float aimdir, float spread, float range, CBlob@ spray
 	return 1;
 }
 
-float sprayAer(int power, float aimdir, float spread, float range, CBlob@ spray, CBlob@ user)
+shared float sprayAer(int power, float aimdir, float spread, float range, CBlob@ spray, CBlob@ user)
 {
 	if(getNet().isClient())
 	{
 		for (int i = 0; i < 8; i++)
 		{
-			CRenderParticleArrow newpart(sprayPSC, false, false, 4, 0, elementlist[4].color, true, 0);
+			CRenderParticleArrow newpart(sprayPSC, false, false, 4, 0, getElementList()[4].color, true, 0);
 			newpart.velocity = Vec2f(1, 0).RotateBy(aimdir + (XORRandom(1000) / 500.0 - 1.0) * (spread / 6)) * range * (XORRandom(1000) / 2000.0 + 0.5) / 8;
 			newpart.position = user.getPosition() /*+ Vec2f(float(XORRandom(1000) / 1000.0 - 0.5) * 16, float(XORRandom(1000) / 1000.0 - 0.5) * 16)*/;
 			addParticleToList(newpart);
@@ -840,7 +840,7 @@ float sprayAer(int power, float aimdir, float spread, float range, CBlob@ spray,
 	return 2;
 }
 
-float sprayOrder(int power, float aimdir, float spread, float range, CBlob@ spray, CBlob@ user)
+shared float sprayOrder(int power, float aimdir, float spread, float range, CBlob@ spray, CBlob@ user)
 {
 	Random rando(XORRandom(0x7FFFFFFF));
 	
@@ -856,7 +856,7 @@ float sprayOrder(int power, float aimdir, float spread, float range, CBlob@ spra
 	{
 		for (int i = 0; i < 8; i++)
 		{
-			CRenderParticleArrow newpart(sprayPSC, false, false, 4, 0, elementlist[7].color, true, 0);
+			CRenderParticleArrow newpart(sprayPSC, false, false, 4, 0, getElementList()[7].color, true, 0);
 			newpart.velocity = Vec2f(1, 0).RotateBy(aimdir + (XORRandom(1000) / 500.0 - 1.0) * (spread / 2)) * range * (XORRandom(1000) / 2000.0 + 0.5) / 8;
 			newpart.position = user.getPosition() /*+ Vec2f(float(XORRandom(1000) / 1000.0 - 0.5) * 16, float(XORRandom(1000) / 1000.0 - 0.5) * 16)*/;
 			addParticleToList(newpart);
@@ -867,7 +867,7 @@ float sprayOrder(int power, float aimdir, float spread, float range, CBlob@ spra
 	return 0.1;
 }
 
-float sprayEntropy(int power, float aimdir, float spread, float range, CBlob@ spray, CBlob@ user)
+shared float sprayEntropy(int power, float aimdir, float spread, float range, CBlob@ spray, CBlob@ user)
 {
 	Random rando(XORRandom(0x7FFFFFFF));
 	
@@ -885,7 +885,7 @@ float sprayEntropy(int power, float aimdir, float spread, float range, CBlob@ sp
 	{
 		for (int i = 0; i < 8; i++)
 		{
-			CRenderParticleArrow newpart(sprayPSC, false, false, 4, 0, elementlist[8].color, true, 0);
+			CRenderParticleArrow newpart(sprayPSC, false, false, 4, 0, getElementList()[8].color, true, 0);
 			newpart.velocity = Vec2f(1, 0).RotateBy(aimdir + (XORRandom(1000) / 500.0 - 1.0) * (spread / 2)) * range * (XORRandom(1000) / 2000.0 + 0.5) / 8;
 			newpart.position = user.getPosition() /*+ Vec2f(float(XORRandom(1000) / 1000.0 - 0.5) * 16, float(XORRandom(1000) / 1000.0 - 0.5) * 16)*/;
 			addParticleToList(newpart);
@@ -896,7 +896,7 @@ float sprayEntropy(int power, float aimdir, float spread, float range, CBlob@ sp
 	return 0.1;
 }
 
-float sprayLife(int power, float aimdir, float spread, float range, CBlob@ spray, CBlob@ user)
+shared float sprayLife(int power, float aimdir, float spread, float range, CBlob@ spray, CBlob@ user)
 {
 	HitInfo@[] list;
 	CMap@ map = getMap();
@@ -920,7 +920,7 @@ float sprayLife(int power, float aimdir, float spread, float range, CBlob@ spray
 	{
 		for (int i = 0; i < 8; i++)
 		{
-			CRenderParticleArrow newpart(sprayPSC, false, false, 4, 0, elementlist[1].color, true, 0);
+			CRenderParticleArrow newpart(sprayPSC, false, false, 4, 0, getElementList()[1].color, true, 0);
 			newpart.velocity = Vec2f(1, 0).RotateBy(aimdir + (XORRandom(1000) / 500.0 - 1.0) * (spread / 2)) * range * (XORRandom(1000) / 2000.0 + 0.5) / 8;
 			newpart.position = user.getPosition() /*+ Vec2f(float(XORRandom(1000) / 1000.0 - 0.5) * 16, float(XORRandom(1000) / 1000.0 - 0.5) * 16)*/;
 			addParticleToList(newpart);
@@ -931,7 +931,7 @@ float sprayLife(int power, float aimdir, float spread, float range, CBlob@ spray
 	return 0.1;
 }
 
-float sprayNatura(int power, float aimdir, float spread, float range, CBlob@ spray, CBlob@ user)
+shared float sprayNatura(int power, float aimdir, float spread, float range, CBlob@ spray, CBlob@ user)
 {
 	HitInfo@[] list;
 	CMap@ map = getMap();
@@ -967,7 +967,7 @@ float sprayNatura(int power, float aimdir, float spread, float range, CBlob@ spr
 	{
 		for (int i = 0; i < 8; i++)
 		{
-			CRenderParticleArrow newpart(sprayPSC, false, false, 4, 0, elementlist[2].color, true, 0);
+			CRenderParticleArrow newpart(sprayPSC, false, false, 4, 0, getElementList()[2].color, true, 0);
 			newpart.velocity = Vec2f(1, 0).RotateBy(aimdir + (XORRandom(1000) / 500.0 - 1.0) * (spread / 2)) * range * (XORRandom(1000) / 2000.0 + 0.5) / 8;
 			newpart.position = user.getPosition() /*+ Vec2f(float(XORRandom(1000) / 1000.0 - 0.5) * 16, float(XORRandom(1000) / 1000.0 - 0.5) * 16)*/;
 			addParticleToList(newpart);
@@ -976,7 +976,7 @@ float sprayNatura(int power, float aimdir, float spread, float range, CBlob@ spr
 	return 1;
 }
 
-float sprayPurity(int power, float aimdir, float spread, float range, CBlob@ spray, CBlob@ user)
+shared float sprayPurity(int power, float aimdir, float spread, float range, CBlob@ spray, CBlob@ user)
 {
 	Random rando(XORRandom(0x7FFFFFFF));
 	
@@ -994,7 +994,7 @@ float sprayPurity(int power, float aimdir, float spread, float range, CBlob@ spr
 	{
 		for (int i = 0; i < 8; i++)
 		{
-			CRenderParticleArrow newpart(sprayPSC, false, false, 4, 0, elementlist[11].color, true, 0);
+			CRenderParticleArrow newpart(sprayPSC, false, false, 4, 0, getElementList()[11].color, true, 0);
 			newpart.velocity = Vec2f(1, 0).RotateBy(aimdir + (XORRandom(1000) / 500.0 - 1.0) * (spread / 2)) * range * (XORRandom(1000) / 2000.0 + 0.5) / 8;
 			newpart.position = user.getPosition() /*+ Vec2f(float(XORRandom(1000) / 1000.0 - 0.5) * 16, float(XORRandom(1000) / 1000.0 - 0.5) * 16)*/;
 			addParticleToList(newpart);
@@ -1005,7 +1005,7 @@ float sprayPurity(int power, float aimdir, float spread, float range, CBlob@ spr
 	return 0.1;
 }
 
-float sprayCorruption(int power, float aimdir, float spread, float range, CBlob@ spray, CBlob@ user)
+shared float sprayCorruption(int power, float aimdir, float spread, float range, CBlob@ spray, CBlob@ user)
 {
 	Random rando(XORRandom(0x7FFFFFFF));
 	
@@ -1024,7 +1024,7 @@ float sprayCorruption(int power, float aimdir, float spread, float range, CBlob@
 	{
 		for (int i = 0; i < 8; i++)
 		{
-			CRenderParticleArrow newpart(sprayPSC, false, false, 4, 0, elementlist[10].color, true, 0);
+			CRenderParticleArrow newpart(sprayPSC, false, false, 4, 0, getElementList()[10].color, true, 0);
 			newpart.velocity = Vec2f(1, 0).RotateBy(aimdir + (XORRandom(1000) / 500.0 - 1.0) * (spread / 2)) * range * (XORRandom(1000) / 2000.0 + 0.5) / 8;
 			newpart.position = user.getPosition() /*+ Vec2f(float(XORRandom(1000) / 1000.0 - 0.5) * 16, float(XORRandom(1000) / 1000.0 - 0.5) * 16)*/;
 			addParticleToList(newpart);
@@ -1033,7 +1033,7 @@ float sprayCorruption(int power, float aimdir, float spread, float range, CBlob@
 	return 1;
 }
 
-float sprayIgnis(int power, float aimdir, float spread, float range, CBlob@ spray, CBlob@ user)
+shared float sprayIgnis(int power, float aimdir, float spread, float range, CBlob@ spray, CBlob@ user)
 {
 	CMap@ map = getMap();
 	if(getGameTime() % (100 / power) == 0)
@@ -1059,7 +1059,7 @@ float sprayIgnis(int power, float aimdir, float spread, float range, CBlob@ spra
 	{
 		for (int i = 0; i < 8; i++)
 		{
-			CRenderParticleArrow newpart(sprayPSC, false, false, 4, 0, elementlist[5].color, true, 0);
+			CRenderParticleArrow newpart(sprayPSC, false, false, 4, 0, getElementList()[5].color, true, 0);
 			newpart.velocity = Vec2f(1, 0).RotateBy(aimdir + (XORRandom(1000) / 500.0 - 1.0) * (spread / 2)) * range * (XORRandom(1000) / 2000.0 + 0.5) / 8;
 			newpart.position = user.getPosition() /*+ Vec2f(float(XORRandom(1000) / 1000.0 - 0.5) * 16, float(XORRandom(1000) / 1000.0 - 0.5) * 16)*/;
 			addParticleToList(newpart);
@@ -1068,7 +1068,7 @@ float sprayIgnis(int power, float aimdir, float spread, float range, CBlob@ spra
 	return 1;
 }
 
-float sprayAqua(int power, float aimdir, float spread, float range, CBlob@ spray, CBlob@ user)
+shared float sprayAqua(int power, float aimdir, float spread, float range, CBlob@ spray, CBlob@ user)
 {
 	CMap@ map = getMap();
 	for(int i = 0; i < power; i++)
@@ -1098,7 +1098,7 @@ float sprayAqua(int power, float aimdir, float spread, float range, CBlob@ spray
 	{
 		for (int i = 0; i < 8; i++)
 		{
-			CRenderParticleArrow newpart(sprayPSC, false, false, 4, 0, elementlist[9].color, true, 0);
+			CRenderParticleArrow newpart(sprayPSC, false, false, 4, 0, getElementList()[9].color, true, 0);
 			newpart.velocity = Vec2f(1, 0).RotateBy(aimdir + (XORRandom(1000) / 500.0 - 1.0) * (spread / 2)) * range * (XORRandom(1000) / 2000.0 + 0.5) / 8;
 			newpart.position = user.getPosition() /*+ Vec2f(float(XORRandom(1000) / 1000.0 - 0.5) * 16, float(XORRandom(1000) / 1000.0 - 0.5) * 16)*/;
 			addParticleToList(newpart);
@@ -1109,7 +1109,7 @@ float sprayAqua(int power, float aimdir, float spread, float range, CBlob@ spray
 
 
 
-float sprayTerra(int power, float aimdir, float spread, float range, CBlob@ spray, CBlob@ user)
+shared float sprayTerra(int power, float aimdir, float spread, float range, CBlob@ spray, CBlob@ user)
 {
 	CMap@ map = getMap();
 	
@@ -1150,7 +1150,7 @@ float sprayTerra(int power, float aimdir, float spread, float range, CBlob@ spra
 	{
 		for (int i = 0; i < 8; i++)
 		{
-			CRenderParticleArrow newpart(sprayPSC, false, false, 4, 0, elementlist[6].color, true, 0);
+			CRenderParticleArrow newpart(sprayPSC, false, false, 4, 0, getElementList()[6].color, true, 0);
 			newpart.velocity = Vec2f(1, 0).RotateBy(aimdir + (XORRandom(1000) / 500.0 - 1.0) * (spread / 2)) * range * (XORRandom(1000) / 2000.0 + 0.5) / 8;
 			newpart.position = user.getPosition();
 			addParticleToList(newpart);
@@ -1159,7 +1159,7 @@ float sprayTerra(int power, float aimdir, float spread, float range, CBlob@ spra
 	return 1;
 }
 
-bool entropyEffect(CMap@ map, Vec2f pos)
+shared bool entropyEffect(CMap@ map, Vec2f pos)
 {
 	Tile tile = map.getTile(pos);
 	bool activated = false;
@@ -1245,7 +1245,7 @@ bool entropyEffect(CMap@ map, Vec2f pos)
 	return activated;
 }
 
-bool orderEffect(CMap@ map, Vec2f pos)
+shared bool orderEffect(CMap@ map, Vec2f pos)
 {
 	CBlob@ blob = map.getBlobAtPosition(pos);
 	if(blob !is null && blob.hasScript("BuildingEffects.as"))//this might not be the best way to check but "too bad"
@@ -1338,91 +1338,91 @@ bool orderEffect(CMap@ map, Vec2f pos)
 	return activated;
 }
 //VIAL INGEST BEHAVIOR HERE
-bool vialIngestBlank(CBlob@ drinker, CBlob@ vial, f32 power)
+shared bool vialIngestBlank(CBlob@ drinker, CBlob@ vial, f32 power)
 {
 	return true;
 }
 
-bool vialIngestEcto(CBlob@ drinker, CBlob@ vial, f32 power)
+shared bool vialIngestEcto(CBlob@ drinker, CBlob@ vial, f32 power)
 {
-	applyFxGhostlike(drinker,900 * power,1);
-	applyFxLowGrav(drinker,900 * power,100);
+	FxGhostlike::apply(drinker,900 * power,1);
+	FxLowGrav::apply(drinker,900 * power,100);
 	return true;
 }
-bool vialIngestLife(CBlob@ drinker, CBlob@ vial, f32 power)
+shared bool vialIngestLife(CBlob@ drinker, CBlob@ vial, f32 power)
 {
 	drinker.server_SetHealth(Maths::Min(drinker.getHealth() + float(power) * 0.2, drinker.getInitialHealth() * 2));
 	return true;
 }
-bool vialIngestNatura(CBlob@ drinker, CBlob@ vial, f32 power)
+shared bool vialIngestNatura(CBlob@ drinker, CBlob@ vial, f32 power)
 {
 	padNatura(drinker,power * 5,vial);
 	return true;
 }
-bool vialIngestForce(CBlob@ drinker, CBlob@ vial, f32 power)
+shared bool vialIngestForce(CBlob@ drinker, CBlob@ vial, f32 power)
 {
 	drinker.setVelocity(Vec2f(0, -16 * power));
 	return true;
 }
-bool vialIngestAer(CBlob@ drinker, CBlob@ vial, f32 power)
+shared bool vialIngestAer(CBlob@ drinker, CBlob@ vial, f32 power)
 {
-	applyFxLightFall(drinker,900 * power,5 * power);
+	FxLightFall::apply(drinker,900 * power,5 * power);
 	return true;
 }
-bool vialIngestIgnis(CBlob@ drinker, CBlob@ vial, f32 power)
+shared bool vialIngestIgnis(CBlob@ drinker, CBlob@ vial, f32 power)
 {
 	vial.server_Hit(drinker,drinker.getPosition(), Vec2f(0,0),1,Hitters::fire,true);
 	return true;
 }
-bool vialIngestTerra(CBlob@ drinker, CBlob@ vial, f32 power)
+shared bool vialIngestTerra(CBlob@ drinker, CBlob@ vial, f32 power)
 {
 	padTerra(drinker,power*5,vial);
 	return true;
 }
-bool vialIngestOrder(CBlob@ drinker, CBlob@ vial, f32 power)
+shared bool vialIngestOrder(CBlob@ drinker, CBlob@ vial, f32 power)
 {
 	padOrder(drinker,power*5,vial);
 	return true;
 }
-bool vialIngestEntropy(CBlob@ drinker, CBlob@ vial, f32 power)
+shared bool vialIngestEntropy(CBlob@ drinker, CBlob@ vial, f32 power)
 {
 	vial.server_Hit(drinker, drinker.getPosition(), Vec2f_zero, 6 * power, Hitters::spikes,true);
 	return true;
 }
-bool vialIngestAqua(CBlob@ drinker, CBlob@ vial, f32 power)
+shared bool vialIngestAqua(CBlob@ drinker, CBlob@ vial, f32 power)
 {
 	padAqua(drinker,power*5,vial);
 	return true;
 }
-bool vialIngestCorruption(CBlob@ drinker, CBlob@ vial, f32 power)
+shared bool vialIngestCorruption(CBlob@ drinker, CBlob@ vial, f32 power)
 {
 	return true;
 }
-bool vialIngestPurity(CBlob@ drinker, CBlob@ vial, f32 power)
+shared bool vialIngestPurity(CBlob@ drinker, CBlob@ vial, f32 power)
 {
 	return true;
 }
-bool vialIngestUnholy(CBlob@ drinker, CBlob@ vial, f32 power)
+shared bool vialIngestUnholy(CBlob@ drinker, CBlob@ vial, f32 power)
 {
 	return true;
 }
-bool vialIngestHoly(CBlob@ drinker, CBlob@ vial, f32 power)
+shared bool vialIngestHoly(CBlob@ drinker, CBlob@ vial, f32 power)
 {
 	return true;
 }
-bool vialIngestYeet(CBlob@ drinker, CBlob@ vial, f32 power)
+shared bool vialIngestYeet(CBlob@ drinker, CBlob@ vial, f32 power)
 {
 	return true;
 }
 
 //VIAL SPLASH BEHAVIOR HERE
-bool vialSplashBlank(CBlob@ vial, f32 power)
+shared bool vialSplashBlank(CBlob@ vial, f32 power)
 {
 
 	return true;
 }
 
-bool vialSplashEcto(CBlob@ vial, f32 power)
+shared bool vialSplashEcto(CBlob@ vial, f32 power)
 {
 	CMap@ map = getMap(); 
 	CBlob@[] blobs;
@@ -1431,12 +1431,12 @@ bool vialSplashEcto(CBlob@ vial, f32 power)
 	{
 		CBlob@ blob = blobs[i];
 		if(map.rayCastSolidNoBlobs(vial.getPosition(),blob.getPosition())){continue;}
-		applyFxGhostlike(blob,900 * power,1);	
-		applyFxLowGrav(blob,900 * power,100);
+		FxGhostlike::apply(blob,900 * power,1);	
+		FxLowGrav::apply(blob,900 * power,100);
 	}
 	return true;
 }
-bool vialSplashLife(CBlob@ vial, f32 power)
+shared bool vialSplashLife(CBlob@ vial, f32 power)
 {
 	CMap@ map = getMap(); 
 	CBlob@[] blobs;
@@ -1449,7 +1449,7 @@ bool vialSplashLife(CBlob@ vial, f32 power)
 	}
 	return true;
 }
-bool vialSplashNatura(CBlob@ vial, f32 power)
+shared bool vialSplashNatura(CBlob@ vial, f32 power)
 {
 	CMap@ map = getMap(); 
 	CBlob@[] blobs;
@@ -1462,7 +1462,7 @@ bool vialSplashNatura(CBlob@ vial, f32 power)
 	}
 	return true;
 }
-bool vialSplashForce(CBlob@ vial, f32 power)
+shared bool vialSplashForce(CBlob@ vial, f32 power)
 {
 	CMap@ map = getMap(); 
 	CBlob@[] blobs;
@@ -1480,7 +1480,7 @@ bool vialSplashForce(CBlob@ vial, f32 power)
 	}
 	return true;
 }
-bool vialSplashAer(CBlob@ vial, f32 power)
+shared bool vialSplashAer(CBlob@ vial, f32 power)
 {
 	CMap@ map = getMap(); 
 	CBlob@[] blobs;
@@ -1498,7 +1498,7 @@ bool vialSplashAer(CBlob@ vial, f32 power)
 	}
 	return true;
 }
-bool vialSplashIgnis(CBlob@ vial, f32 power)
+shared bool vialSplashIgnis(CBlob@ vial, f32 power)
 {
 	CMap@ map = getMap(); 
 	CBlob@[] blobs;
@@ -1511,7 +1511,7 @@ bool vialSplashIgnis(CBlob@ vial, f32 power)
 	}
 	return true;
 }
-bool vialSplashTerra(CBlob@ vial, f32 power)
+shared bool vialSplashTerra(CBlob@ vial, f32 power)
 {
 	for(int i = 0; i < 50 * power; i++)
 	{
@@ -1519,7 +1519,7 @@ bool vialSplashTerra(CBlob@ vial, f32 power)
 	}
 	return true;
 }
-bool vialSplashOrder(CBlob@ vial, f32 power)
+shared bool vialSplashOrder(CBlob@ vial, f32 power)
 {
 	for(int i = 0; i < 50 * power; i++)
 	{
@@ -1527,7 +1527,7 @@ bool vialSplashOrder(CBlob@ vial, f32 power)
 	}
 	return true;
 }
-bool vialSplashEntropy(CBlob@ vial, f32 power)
+shared bool vialSplashEntropy(CBlob@ vial, f32 power)
 {
 	for(int i = 0; i < 50 * power; i++)
 	{
@@ -1535,7 +1535,7 @@ bool vialSplashEntropy(CBlob@ vial, f32 power)
 	}
 	return true;
 }
-bool vialSplashAqua(CBlob@ vial, f32 power)
+shared bool vialSplashAqua(CBlob@ vial, f32 power)
 {
 	CMap@ map = getMap(); 
 	CBlob@[] blobs;
@@ -1548,7 +1548,7 @@ bool vialSplashAqua(CBlob@ vial, f32 power)
 	}
 	return true;
 }
-bool vialSplashCorruption(CBlob@ vial, f32 power)
+shared bool vialSplashCorruption(CBlob@ vial, f32 power)
 {
 	for(int i = 0; i < 50 * power; i++)
 	{
@@ -1556,7 +1556,7 @@ bool vialSplashCorruption(CBlob@ vial, f32 power)
 	}
 	return true;
 }
-bool vialSplashPurity(CBlob@ vial, f32 power)
+shared bool vialSplashPurity(CBlob@ vial, f32 power)
 {
 	for(int i = 0; i < 50 * power; i++)
 	{
@@ -1564,15 +1564,15 @@ bool vialSplashPurity(CBlob@ vial, f32 power)
 	}
 	return true;
 }
-bool vialSplashUnholy(CBlob@ vial, f32 power)
+shared bool vialSplashUnholy(CBlob@ vial, f32 power)
 {
 	return true;
 }
-bool vialSplashHoly(CBlob@ vial, f32 power)
+shared bool vialSplashHoly(CBlob@ vial, f32 power)
 {
 	return true;
 }
-bool vialSplashYeet(CBlob@ vial, f32 power)
+shared bool vialSplashYeet(CBlob@ vial, f32 power)
 {
 	return true;
 }

--- a/Entities/Alchemy/Foci/AlchemicalBinder.as
+++ b/Entities/Alchemy/Foci/AlchemicalBinder.as
@@ -24,19 +24,20 @@ void onTick(CBlob@ this)
 {
 	if(this.get_bool("active"))
 	{
-	CBlob@ shard = this.getInventory().getItem(0);
+		array<CElementSetup> @elementlist = @getElementList();
+		CBlob@ shard = this.getInventory().getItem(0);
 
-	if(shard is null) {return;}
-	if(shard.getConfig() != "soul_chunk") {return;}
+		if(shard is null) {return;}
+		if(shard.getConfig() != "soul_chunk") {return;}
 
-	CPlayer@ player = getPlayerByUsername(shard.get_string("player_username"));
-	if(player is null) {return;}
-	CBlob@ pblob = player.getBlob();
-	if(pblob is null) {return;}
+		CPlayer@ player = getPlayerByUsername(shard.get_string("player_username"));
+		if(player is null) {return;}
+		CBlob@ pblob = player.getBlob();
+		if(pblob is null) {return;}
 
 
-	CAlchemyTank@ tank = getTank(this, 0);
-	//int active_elements = 0;
+		CAlchemyTank@ tank = getTank(this, 0);
+		//int active_elements = 0;
 		for (int i = 0; i < elementlist.length; i++)
 		{
 			if(tank.storage.elements[i] >= 1)

--- a/Entities/Alchemy/Foci/AlchemicalPad.as
+++ b/Entities/Alchemy/Foci/AlchemicalPad.as
@@ -34,6 +34,7 @@ void onTick(CBlob@ this)
 		this.add_u16("cooldown", -1);
 	else
 	{
+		array<CElementSetup> @elementlist = @getElementList();
 		CBlob@[] blobs;
 		if(this.getOverlapping(@blobs) && this.get_bool("active") && getNet().isServer())
 		{
@@ -69,6 +70,7 @@ void GetButtonsFor(CBlob@ this, CBlob@ caller)
 
 void onCommand(CBlob@ this, u8 cmd, CBitStream@ params)
 {
+	array<CElementSetup> @elementlist = @getElementList();
 	if(this.getCommandID("toggle") == cmd)
 	{
 		this.set_bool("active", this.get_bool("active") ? false : true);

--- a/Entities/Alchemy/Foci/AlchemicalWard.as
+++ b/Entities/Alchemy/Foci/AlchemicalWard.as
@@ -43,6 +43,8 @@ void onTick(CSprite@ this)
 {
 	CSpriteLayer@ layer = this.getSpriteLayer("runes");
 	CBlob@ blob = this.getBlob();
+	array<CElementSetup> @elementlist = @getElementList();
+
 	if(blob.get_u8("lasteleid") == 255)
 	{
 		layer.SetColor(SColor(0, 0, 0, 0));
@@ -58,6 +60,7 @@ void renderArea(CBlob@ this, int id)
 {
 	if(this.get_u8("lasteleid") == 255)
 		return;
+	array<CElementSetup> @elementlist = @getElementList();
 	array<Vertex> vertlist(0);
 	
 		
@@ -104,6 +107,7 @@ void renderArea(CBlob@ this, int id)
 
 void onTick(CBlob@ this)
 {
+	array<CElementSetup> @elementlist = @getElementList();
 	this.set_u8("lasteleid", 255);
 	if(this.get_bool("active"))
 	{

--- a/Entities/Alchemy/Foci/vial.as
+++ b/Entities/Alchemy/Foci/vial.as
@@ -20,6 +20,7 @@ void onInit(CSprite@ this)
 void onTick(CBlob@ this)
 {
     CAlchemyTank@ tank = getTank(this, 0);
+    array<CElementSetup> @elementlist = @getElementList();
     int id = firstId(tank);
     this.setInventoryName(id > -1 ? ("Vial of " + elementlist[id].visiblename) : "Empty Vial");
 }
@@ -29,6 +30,7 @@ void onTick(CSprite@ this)
     CBlob@ blob = this.getBlob();
 
     CAlchemyTank@ tank = getTank(blob, 0);
+    array<CElementSetup> @elementlist = @getElementList();
     CSpriteLayer@ layer = this.getSpriteLayer("content");
 
     if(getGameTime() % 4 == 0)
@@ -73,6 +75,7 @@ void onDie(CBlob@ this)
     Sound::Play("shatter.ogg", this.getPosition(),1, 0.75 + (XORRandom(25)/100.0));
 
     CAlchemyTank@ tank = getTank(this, 0);
+    array<CElementSetup> @elementlist = @getElementList();
     int id = firstId(tank);
     if(id <= -1){return;}
     f32 ammount = tank.storage.getElement(id);

--- a/Entities/Alchemy/Producer/AlchemicalCheatMachine.as
+++ b/Entities/Alchemy/Producer/AlchemicalCheatMachine.as
@@ -17,6 +17,7 @@ void onInit(CBlob@ this)
 void onTick(CBlob@ this)
 {
 	CAlchemyTank@ output = getTank(this, 0);
+	array<CElementSetup> @elementlist = @getElementList();
 	
 	for (int i = 0; i < elementlist.length; i++)
 	{
@@ -37,6 +38,7 @@ void GetButtonsFor(CBlob@ this, CBlob@ caller)
 
 void onCommand(CBlob@ this, u8 cmd, CBitStream@ params)
 {
+	array<CElementSetup> @elementlist = @getElementList();
 	if(this.getCommandID("configmenu") == cmd)
 	{
 		CBlob@ caller = getBlobByNetworkID(params.read_u16());

--- a/Entities/Alchemy/Routing/AlchemicalSorter.as
+++ b/Entities/Alchemy/Routing/AlchemicalSorter.as
@@ -53,6 +53,7 @@ void GetButtonsFor(CBlob@ this, CBlob@ caller)
 
 void onCommand(CBlob@ this, u8 cmd, CBitStream@ params)
 {
+	array<CElementSetup> @elementlist = @getElementList();
 	if(this.getCommandID("configmenu") == cmd)
 	{
 		CBlob@ caller = getBlobByNetworkID(params.read_u16());
@@ -85,6 +86,7 @@ void onCommand(CBlob@ this, u8 cmd, CBitStream@ params)
 
 void makeSorterMenu(CBlob@ this, CBlob@ caller)
 {
+	array<CElementSetup> @elementlist = @getElementList();
 	caller.ClearMenus();
 	int buttons = elementlist.length + 2 - HIDDEN_ELEMENTS;
 	Vec2f screencenter(getScreenWidth() / 2, getScreenHeight() / 2);

--- a/Entities/Characters/Abilities/AbilitiesCommon.as
+++ b/Entities/Characters/Abilities/AbilitiesCommon.as
@@ -4,7 +4,7 @@
 #include "ExplosionCommon.as"
 #include "Hitters.as"
 
-interface IAbility
+shared interface IAbility
 {
     string getTextureName();
     CBlob@ getBlob();
@@ -20,7 +20,7 @@ interface IAbility
 	string getName();
 }
 
-class CAbilityBase : IAbility
+shared class CAbilityBase : IAbility
 {
     void onTick(){}
 	void onDie(){}
@@ -54,7 +54,7 @@ class CAbilityBase : IAbility
     void onCommand( u8 cmd, CBitStream @params ){}
 }
 
-class CAbilityEmpty : CAbilityBase
+shared class CAbilityEmpty : CAbilityBase
 {
 	string getTextureName() override
 	{
@@ -75,7 +75,7 @@ class CAbilityEmpty : CAbilityBase
 	}
 }
 
-class CToggleableAbillityBase : CAbilityBase
+shared class CToggleableAbillityBase : CAbilityBase
 {
     CToggleableAbillityBase()
     {
@@ -90,7 +90,7 @@ class CToggleableAbillityBase : CAbilityBase
     }
 }
 
-class CPoint : CAbilityBase
+shared class CPoint : CAbilityBase
 {
     CPoint(string textureName, CBlob@ blob)
     {
@@ -150,7 +150,7 @@ class CPoint : CAbilityBase
     }
 }
 
-class CConsume : CAbilityBase
+shared class CConsume : CAbilityBase
 {
 	int unstableCoresConsumed = 0;
 
@@ -322,14 +322,14 @@ class CConsume : CAbilityBase
 		f32 ammount = tank.storage.getElement(id);
 		f32 power = ammount/tank.maxelements;
 
-		elementlist[id].vialIngestbehavior(blob,vial,power);
+		getElementList()[id].vialIngestbehavior(blob,vial,power);
 
 		tank.storage.setElement(id,0);
 	}
 
 }
 
-class CSelfDestruct : CAbilityBase
+shared class CSelfDestruct : CAbilityBase
 {
 	f32 instability = 0;
 	bool cheaterMode = false;
@@ -402,7 +402,7 @@ class CSelfDestruct : CAbilityBase
 	}
 }
 
-class CAbsorb : CAbilityBase
+shared class CAbsorb : CAbilityBase
 {
 	CAbsorb(string _textureName, CBlob@ _blob)
 	{
@@ -449,7 +449,7 @@ class CAbsorb : CAbilityBase
 	}
 }
 
-class COvertake : CAbilityBase
+shared class COvertake : CAbilityBase
 {
 	COvertake(string _textureName, CBlob@ _blob)
 	{
@@ -599,7 +599,7 @@ enum EAbilities
 	Overtake = 5
 }
 
-class CAbilityMasterList
+shared class CAbilityMasterList
 {
 	private IAbility@[] abilities;
 	CBlob@ blob;
@@ -631,13 +631,23 @@ class CAbilityMasterList
 	}
 }
 
-f32 fDrawScale = 1; // this is actually 2x scale idk why kag does this
-f32 fRealScale = fDrawScale/0.5;
-Vec2f slotDimentions = Vec2f(16,16);
-Vec2f slotSpacing = Vec2f(4,0);
-Vec2f borderDimentions = Vec2f(18,18);
-Vec2f borderOffset = Vec2f(-2,-2);
-class CAbilityBar
+// Angelscript doesn't support shared global vars, so I'm grouping these into singleton
+// f32 fDrawScale = 1; // this is actually 2x scale idk why kag does this
+// f32 fRealScale = fDrawScale/0.5;
+// Vec2f slotDimensions = Vec2f(16,16);
+// Vec2f slotSpacing = Vec2f(4,0);
+// Vec2f borderDimentions = Vec2f(18,18);
+// Vec2f borderOffset = Vec2f(-2,-2);
+
+shared f32 fDrawScale()			{return 1;				}
+shared f32 fRealScale()			{return fDrawScale()/0.5;	}
+shared Vec2f slotDimensions()	{return Vec2f(16,16);	}
+shared Vec2f slotSpacing()		{return Vec2f(4,0);		}
+shared Vec2f borderDimentions()	{return Vec2f(18,18);	}
+shared Vec2f borderOffset()		{return Vec2f(-2,-2);	}
+
+
+shared class CAbilityBar
 {	
 	CAbilityMasterList@ masterList;
 	CBlob@ blob;
@@ -709,7 +719,7 @@ class CAbilityBar
 
 	Vec2f getSlotPosition(u32 i)
 	{
-		return initialBarOffset + (slotSpacing * i) + Vec2f(slotDimentions.x * i * fRealScale, initialBarOffset.y);
+		return initialBarOffset + (slotSpacing() * i) + Vec2f(slotDimensions().x * i * fRealScale(), initialBarOffset.y);
 	}
 
 	bool isSlotHovered(u32 i)
@@ -717,7 +727,7 @@ class CAbilityBar
 		Vec2f slotPos = getSlotPosition(i);
 		Vec2f mpos = getControls().getMouseScreenPos();
 
-		return mpos.x >= slotPos.x && mpos.x <= (slotPos.x + slotDimentions.x * fRealScale) && mpos.y >= slotPos.y && mpos.y <= (slotPos.y + slotDimentions.y * fRealScale);
+		return mpos.x >= slotPos.x && mpos.x <= (slotPos.x + slotDimensions().x * fRealScale()) && mpos.y >= slotPos.y && mpos.y <= (slotPos.y + slotDimensions().y * fRealScale());
 	}
 
 	int getHoveredSlot()
@@ -761,20 +771,20 @@ class CAbilityBar
 	}
 	Vec2f getBarEndPos()
 	{
-		return getSlotPosition(slots.length - 1) + slotDimentions * fRealScale + Vec2f(backgroundThickness,backgroundThickness);
+		return getSlotPosition(slots.length - 1) + slotDimensions() * fRealScale() + Vec2f(backgroundThickness,backgroundThickness);
 	}
 	Vec2f getNameDrawStartPos()
 	{
 		CAbilityManager@ m;
 		blob.get("AbilityManager",@m);
 		return m.abilityMenu.menuOpenTargetPos+
-		Vec2f(m.abilityMenu.menuButtonDimentions.x*fRealScale,0);
+		Vec2f(m.abilityMenu.menuButtonDimentions.x*fRealScale(),0);
 	}
 	Vec2f getNameDrawEndPos()
 	{
 		CAbilityManager@ m;
 		blob.get("AbilityManager",@m);
-		return Vec2f(getBarEndPos().x,m.abilityMenu.menuButtonDimentions.y * fRealScale + m.abilityMenu.menuOpenTargetPos.y);
+		return Vec2f(getBarEndPos().x,m.abilityMenu.menuButtonDimentions.y * fRealScale() + m.abilityMenu.menuOpenTargetPos.y);
 	}
 	void onRender()
 	{
@@ -788,15 +798,15 @@ class CAbilityBar
 
 				if(isSlotHovered(i))
 				{
-					GUI::DrawIcon(getAbility(i).getTextureName(),0,slotDimentions,drawPos,fDrawScale,SColor(127,255,255,255));
+					GUI::DrawIcon(getAbility(i).getTextureName(),0,slotDimensions(),drawPos,fDrawScale(),SColor(127,255,255,255));
 				}
 				else
 				{
-					GUI::DrawIcon(getAbility(i).getTextureName(),0,slotDimentions,drawPos,fDrawScale);
+					GUI::DrawIcon(getAbility(i).getTextureName(),0,slotDimensions(),drawPos,fDrawScale());
 				}
 			}
 
-			GUI::DrawIcon(getSelectedAbility().getBorder(),0,borderDimentions,getSlotPosition(selectedSlot) + borderOffset,fDrawScale);
+			GUI::DrawIcon(getSelectedAbility().getBorder(),0,borderDimentions(),getSlotPosition(selectedSlot) + borderOffset(),fDrawScale());
 			GUI::DrawRectangle(getNameDrawStartPos(),getNameDrawEndPos());
 			GUI::DrawTextCentered(getSelectedAbility().getName(), (getNameDrawStartPos() + getNameDrawEndPos())/2, SColor(255,0,0,0));
 			
@@ -809,7 +819,7 @@ class CAbilityBar
 
 }
 
-class CAbilityMenu //this will act as the "unlocked" abilities and run them every tick as well as acting as a menu to add to the bar
+shared class CAbilityMenu //this will act as the "unlocked" abilities and run them every tick as well as acting as a menu to add to the bar
 {
 	CAbilityMasterList@ masterList;
 	CAbilityBar@ bar;
@@ -990,12 +1000,12 @@ class CAbilityMenu //this will act as the "unlocked" abilities and run them ever
 
 	Vec2f getMenuDimentions()
 	{
-		return  Vec2f(3 + columns * (slotDimentions.x * fRealScale) + columns * slotSpacing.x, getRows() * (slotDimentions.y * fRealScale) + getRows() * slotSpacing.x) + Vec2f(0,4);
+		return  Vec2f(3 + columns * (slotDimensions().x * fRealScale()) + columns * slotSpacing().x, getRows() * (slotDimensions().y * fRealScale()) + getRows() * slotSpacing().x) + Vec2f(0,4);
 	}
 
 	Vec2f getItemPos(u32 i)
 	{
-		return Vec2f(i%columns * (slotDimentions.x * fRealScale + slotSpacing.x), (getRows() - 1) * (fRealScale * slotDimentions.y)) + menuCurrentPos + Vec2f(4,4);
+		return Vec2f(i%columns * (slotDimensions().x * fRealScale() + slotSpacing().x), (getRows() - 1) * (fRealScale() * slotDimensions().y)) + menuCurrentPos + Vec2f(4,4);
 	}
 
 	s32 getHoveredItem()
@@ -1005,7 +1015,7 @@ class CAbilityMenu //this will act as the "unlocked" abilities and run them ever
 		{
 			Vec2f itemPos = getItemPos(i);
 
-			if(mpos.x >= itemPos.x && mpos.x <= itemPos.x + (slotDimentions.x * fRealScale) && mpos.y >= itemPos.y && mpos.y <= itemPos.y + (slotDimentions.y * fRealScale))
+			if(mpos.x >= itemPos.x && mpos.x <= itemPos.x + (slotDimensions().x * fRealScale()) && mpos.y >= itemPos.y && mpos.y <= itemPos.y + (slotDimensions().y * fRealScale()))
 			{
 				return i;
 			}
@@ -1029,9 +1039,9 @@ class CAbilityMenu //this will act as the "unlocked" abilities and run them ever
 		Vec2f mpos = getControls().getMouseScreenPos();
 		return 
 		mpos.x >= menuOpenTargetPos.x &&
-		mpos.x <= menuOpenTargetPos.x + menuButtonDimentions.x * fRealScale &&
+		mpos.x <= menuOpenTargetPos.x + menuButtonDimentions.x * fRealScale() &&
 		mpos.y >= menuOpenTargetPos.y  &&
-		mpos.y <= menuOpenTargetPos.y + menuButtonDimentions.y * fRealScale;
+		mpos.y <= menuOpenTargetPos.y + menuButtonDimentions.y * fRealScale();
 
 	}
 
@@ -1047,11 +1057,11 @@ class CAbilityMenu //this will act as the "unlocked" abilities and run them ever
 			//menu button icon
 			if(isMenuButtonHovered())
 			{
-				GUI::DrawIcon("Manage.png", 0, menuButtonDimentions, menuOpenTargetPos,fDrawScale,SColor(255,127,127,127));
+				GUI::DrawIcon("Manage.png", 0, menuButtonDimentions, menuOpenTargetPos,fDrawScale(),SColor(255,127,127,127));
 			}
 			else
 			{
-				GUI::DrawIcon("Manage.png", 0, menuButtonDimentions, menuOpenTargetPos,fDrawScale);
+				GUI::DrawIcon("Manage.png", 0, menuButtonDimentions, menuOpenTargetPos,fDrawScale());
 			}
 
 			menuCurrentPos = Vec2f_lerp(menuCurrentPos,menuOpen ? menuOpenTargetPos : menuClosedTargetPos,0.1);
@@ -1063,11 +1073,11 @@ class CAbilityMenu //this will act as the "unlocked" abilities and run them ever
 				{
 					if(i == heldItem || (heldItem <= -1 && i == getHoveredItem()))
 					{
-						GUI::DrawIcon(getAbility(i).getTextureName(),0,slotDimentions,getItemPos(i),fDrawScale,SColor(127,255,255,255));
+						GUI::DrawIcon(getAbility(i).getTextureName(),0,slotDimensions(),getItemPos(i),fDrawScale(),SColor(127,255,255,255));
 					}
 					else
 					{
-						GUI::DrawIcon(getAbility(i).getTextureName(),0,slotDimentions,getItemPos(i),fDrawScale);
+						GUI::DrawIcon(getAbility(i).getTextureName(),0,slotDimensions(),getItemPos(i),fDrawScale());
 					}
 				}
 
@@ -1083,14 +1093,14 @@ class CAbilityMenu //this will act as the "unlocked" abilities and run them ever
 				//held icon
 				if(heldItem > -1)
 				{
-					GUI::DrawIcon(getAbility(heldItem).getTextureName(), 0, slotDimentions, getControls().getMouseScreenPos() - (slotDimentions * fRealScale)/2,fDrawScale);
+					GUI::DrawIcon(getAbility(heldItem).getTextureName(), 0, slotDimensions(), getControls().getMouseScreenPos() - (slotDimensions() * fRealScale())/2,fDrawScale());
 				}
 			}
 		}
 	}
 }
 
-class CAbilityManager
+shared class CAbilityManager
 {
     CAbilityMasterList@ abilityMasterList;
     CAbilityMenu@ abilityMenu;

--- a/Entities/Equipment/Common/EquipmentSprayerCommon.as
+++ b/Entities/Equipment/Common/EquipmentSprayerCommon.as
@@ -75,6 +75,7 @@ class CSprayerEquipment : CEquipmentCore
 	
 	void fireWeapon(CBlob@ blob, CBlob@ user)
 	{
+		array<CElementSetup> @elementlist = @getElementList();
 		lastshotrotation = angle;
 		fixedsprite = false;
 		//if(this.get_bool("active"))

--- a/Entities/Items/Explosives/ExplosionCommon.as
+++ b/Entities/Items/Explosives/ExplosionCommon.as
@@ -21,7 +21,7 @@
 #include "ShieldCommon.as";
 #include "SplashWater.as";
 
-bool isOwnerBlob(CBlob@ this, CBlob@ that)
+shared bool isOwnerBlob(CBlob@ this, CBlob@ that)
 {
 	//easy check
 	if (this.getDamageOwnerPlayer() is that.getPlayer())
@@ -32,7 +32,7 @@ bool isOwnerBlob(CBlob@ this, CBlob@ that)
 	return (that.getNetworkID() == this.get_u16("explosive_parent"));
 }
 
-void makeSmallExplosionParticle(Vec2f pos)
+shared void makeSmallExplosionParticle(Vec2f pos)
 {
 	ParticleAnimated("Entities/Effects/Sprites/SmallExplosion" + (XORRandom(3) + 1) + ".png",
 	                 pos, Vec2f(0, 0.5f), 0.0f, 1.0f,
@@ -40,7 +40,7 @@ void makeSmallExplosionParticle(Vec2f pos)
 	                 -0.1f, true);
 }
 
-void makeLargeExplosionParticle(Vec2f pos)
+shared void makeLargeExplosionParticle(Vec2f pos)
 {
 	ParticleAnimated("Entities/Effects/Sprites/Explosion.png",
 	                 pos, Vec2f(0, 0.5f), 0.0f, 1.0f,
@@ -48,7 +48,7 @@ void makeLargeExplosionParticle(Vec2f pos)
 	                 -0.1f, true);
 }
 
-void Explode(CBlob@ this, Vec2f pos, f32 radius, f32 damage, string custom_explosion_sound, f32 map_damage_radius, f32 map_damage_ratio, bool map_damage_raycast, u8 custom_hitter, bool should_teamkill)
+shared void Explode(CBlob@ this, Vec2f pos, f32 radius, f32 damage, string custom_explosion_sound, f32 map_damage_radius, f32 map_damage_ratio, bool map_damage_raycast, u8 custom_hitter, bool should_teamkill)
 {
 	CMap@ map = getMap();
 
@@ -432,7 +432,7 @@ void BombermanExplosion(CBlob@ this, f32 radius, f32 damage, f32 map_damage_radi
 
 }
 
-bool canExplosionDamage(CMap@ map, Vec2f tpos, TileType t)
+shared bool canExplosionDamage(CMap@ map, Vec2f tpos, TileType t)
 {
 	CBlob@ blob = map.getBlobAtPosition(tpos); // TODO: make platform get detected
 	bool hasValidFrontBlob = false;
@@ -447,12 +447,12 @@ bool canExplosionDamage(CMap@ map, Vec2f tpos, TileType t)
 		   !(hasValidFrontBlob && isBackwall); // don't destroy backwall if there is a door or trap block
 }
 
-bool canExplosionDestroy(CMap@ map, Vec2f tpos, TileType t)
+shared bool canExplosionDestroy(CMap@ map, Vec2f tpos, TileType t)
 {
 	return !(map.isTileGroundStuff(t));
 }
 
-Vec2f getBombForce(f32 radius, Vec2f hit_blob_pos, Vec2f pos, f32 hit_blob_mass, f32 &out scale)
+shared Vec2f getBombForce(f32 radius, Vec2f hit_blob_pos, Vec2f pos, f32 hit_blob_mass, f32 &out scale)
 {
 	Vec2f offset = hit_blob_pos - pos;
 	f32 distance = offset.Length();
@@ -469,7 +469,7 @@ Vec2f getBombForce(f32 radius, Vec2f hit_blob_pos, Vec2f pos, f32 hit_blob_mass,
 	bombforce *= hit_blob_mass * (3.0f) * scale;
 	return bombforce;
 }
-bool HitBlob(CBlob@ this, CBlob@ hit_blob, f32 radius, f32 damage, const u8 hitter,
+shared bool HitBlob(CBlob@ this, CBlob@ hit_blob, f32 radius, f32 damage, const u8 hitter,
              const bool bother_raycasting = true, const bool should_teamkill = false)
 {
 	Vec2f pos = this.getPosition();
@@ -477,7 +477,7 @@ bool HitBlob(CBlob@ this, CBlob@ hit_blob, f32 radius, f32 damage, const u8 hitt
             bother_raycasting, should_teamkill);
 }
 
-bool HitBlob(CBlob@ this, Vec2f pos, CBlob@ hit_blob, f32 radius, f32 damage, const u8 hitter,
+shared bool HitBlob(CBlob@ this, Vec2f pos, CBlob@ hit_blob, f32 radius, f32 damage, const u8 hitter,
              const bool bother_raycasting = true, const bool should_teamkill = false)
 {
 	CMap@ map = this.getMap();

--- a/Entities/Items/lum/lum.as
+++ b/Entities/Items/lum/lum.as
@@ -58,7 +58,7 @@ void onTick(CSprite@ this)
     {
         CBlob@ blob = blobs[i];
         CAlchemyTank@ tank = getTank(blob, 0);
-
+        array<CElementSetup> @elementlist = @getElementList();
         if(tank !is null)
         {
             for(int i = 0; i < elementlist.size(); i++)

--- a/Entities/StatusFx/DamageModCommon.as
+++ b/Entities/StatusFx/DamageModCommon.as
@@ -1,13 +1,13 @@
 //This will set up a system for damage modifiers
 
-funcdef f32 damageMod(CBlob@ this, CBlob@ hitblob, f32 damage, u8 customdata);
+//funcdef f32 damageMod(CBlob@ this, CBlob@ hitblob, f32 damage, u8 customdata);
 
-interface IDamageMod
+shared interface IDamageMod
 {
 	f32 damageMod(CBlob@, CBlob@, f32, u8);
 }
 
-class CDamageModCore : IDamageMod
+shared class CDamageModCore : IDamageMod
 {
 	string name;
 	
@@ -22,7 +22,7 @@ class CDamageModCore : IDamageMod
 	}
 }
 
-void addDamageMod(CBlob@ this, CDamageModCore@ mod)
+shared void addDamageMod(CBlob@ this, CDamageModCore@ mod)
 {
 	array<CDamageModCore@>@ list;
 	this.get("damagemods", @list);

--- a/Entities/StatusFx/FxCorruptTick.as
+++ b/Entities/StatusFx/FxCorruptTick.as
@@ -6,7 +6,7 @@ void onRender(CSprite@ this)
 {
 	CBlob@ blob = this.getBlob();
 	if(blob.get_u16("fxcorrupttime") != 0)
-	//	removeFxCorrupt(blob);
+	//	FxCorrupt::remove(blob);
 	//else
 		corruptFxRender(blob);
 }

--- a/Entities/StatusFx/FxDamageReduce.as
+++ b/Entities/StatusFx/FxDamageReduce.as
@@ -1,50 +1,55 @@
 //Damage reduction status
 #include "DamageModCommon.as";
-string drscriptname = "FxDamageReduceTick";
 
-/*class CReduceDamageMod : CDamageModCore
-{
-	CReduceDamageMod(string name)
-	{super(name);}
-	
-	f32 damageMod(CBlob@ this, CBlob@ hitblob, f32 damage, u8 customdata)
+namespace FxDamageReduce {
+
+	shared string scriptname() {return "FxDamageReduceTick";}
+
+	/*class CReduceDamageMod : CDamageModCore
 	{
-		print("ran");
-		//if(this.get_u16("fxdamagereducepower") == 0)
-			//return damage;
-		return damage / float(this.get_u16("fxdamagereducepower") + 1);
-	}	
-}*/
-
-//CReduceDamageMod reducemod(drscriptname);
-
-void applyFxDamageReduce(CBlob@ blob, int time, int power)
-{
-	if(!blob.hasScript("FxHook"))
-		return;
-	if(blob.get_u16("fxdamagereducetime") > 0)
-	{
-		if(blob.get_u16("fxdamagereducepower") <= power)
+		CReduceDamageMod(string name)
+		{super(name);}
+		
+		f32 damageMod(CBlob@ this, CBlob@ hitblob, f32 damage, u8 customdata)
 		{
+			print("ran");
+			//if(this.get_u16("fxdamagereducepower") == 0)
+				//return damage;
+			return damage / float(this.get_u16("fxdamagereducepower") + 1);
+		}	
+	}*/
+
+	//CReduceDamageMod reducemod(scriptname());
+
+	shared void apply(CBlob@ blob, int time, int power)
+	{
+		if(!blob.hasScript("FxHook"))
+			return;
+		if(blob.get_u16("fxdamagereducetime") > 0)
+		{
+			if(blob.get_u16("fxdamagereducepower") <= power)
+			{
+				blob.set_u16("fxdamagereducetime", time);
+				blob.set_u16("fxdamagereducepower", power);
+			}
+		}
+		else
+		{
+			//addDamageMod(blob, @reducemod);
 			blob.set_u16("fxdamagereducetime", time);
 			blob.set_u16("fxdamagereducepower", power);
+			CSprite@ sprite = blob.getSprite();
+			if(sprite !is null)
+				sprite.AddScript(scriptname());
 		}
 	}
-	else
+
+	void remove(CBlob@ blob)
 	{
-		//addDamageMod(blob, @reducemod);
-		blob.set_u16("fxdamagereducetime", time);
-		blob.set_u16("fxdamagereducepower", power);
+		//removeDamageMod(blob, @reducemod);
 		CSprite@ sprite = blob.getSprite();
 		if(sprite !is null)
-			sprite.AddScript(drscriptname);
+			sprite.RemoveScript(scriptname());
 	}
-}
 
-void removeFxDamageReduce(CBlob@ blob)
-{
-	//removeDamageMod(blob, @reducemod);
-	CSprite@ sprite = blob.getSprite();
-	if(sprite !is null)
-		sprite.RemoveScript(drscriptname);
 }

--- a/Entities/StatusFx/FxDamageReduceTick.as
+++ b/Entities/StatusFx/FxDamageReduceTick.as
@@ -6,7 +6,7 @@ void onRender(CSprite@ this)
 {
 	CBlob@ blob = this.getBlob();
 	//if(blob.get_u16("fxdamagereducetime") == 0)
-	//	removeFxDamageReduce(blob);
+	//	FxDamageReduce::remove(blob);
 	//else
 		damageReduceRender(blob);
 }

--- a/Entities/StatusFx/FxGhostlike.as
+++ b/Entities/StatusFx/FxGhostlike.as
@@ -1,43 +1,46 @@
 //Damage reduction status
 
 //#include "FxLowGrav.as";
+namespace FxGhostlike {
 
-string scriptnameghost = "FxGhostlikeTick";
+	shared string scriptname() {return "FxGhostlikeTick";}
 
-void applyFxGhostlike(CBlob@ blob, int time, int power)
-{
-	CShape@ shape = blob.getShape();
-	if(!blob.exists("ghostliketogglecoll") && shape !is null)
+	shared void apply(CBlob@ blob, int time, int power)
 	{
-		blob.set_bool("ghostliketogglecoll", shape.getConsts().mapCollisions);
-	}
-	if(blob.hasScript(scriptnameghost))
-	{
-		if(blob.get_u16("fxghostlikepower") <= power)
+		CShape@ shape = blob.getShape();
+		if(!blob.exists("ghostliketogglecoll") && shape !is null)
+		{
+			blob.set_bool("ghostliketogglecoll", shape.getConsts().mapCollisions);
+		}
+		if(blob.hasScript(scriptname()))
+		{
+			if(blob.get_u16("fxghostlikepower") <= power)
+			{
+				blob.set_u16("fxghostliketime", time);
+				blob.set_u16("fxghostlikepower", power);
+				//applyFxLowGrav(blob, time + 100, 100);
+			}
+		}
+		else
 		{
 			blob.set_u16("fxghostliketime", time);
 			blob.set_u16("fxghostlikepower", power);
 			//applyFxLowGrav(blob, time + 100, 100);
+			if(blob.get_bool("ghostliketogglecoll"))
+				shape.getConsts().mapCollisions = false;
+			blob.AddScript(scriptname());
 		}
 	}
-	else
-	{
-		blob.set_u16("fxghostliketime", time);
-		blob.set_u16("fxghostlikepower", power);
-		//applyFxLowGrav(blob, time + 100, 100);
-		if(blob.get_bool("ghostliketogglecoll"))
-			shape.getConsts().mapCollisions = false;
-		blob.AddScript(scriptnameghost);
-	}
-}
 
-void removeFxGhostlike(CBlob@ blob)
-{
-	if(!blob.hasScript(scriptnameghost))
-		return;
-	CShape@ shape = blob.getShape();
-	if(blob.get_bool("ghostliketogglecoll") && shape !is null)
-		shape.getConsts().mapCollisions = true;
-	blob.RemoveScript(scriptnameghost);
-	//removeFxLowGrav(blob);
+	void remove(CBlob@ blob)
+	{
+		if(!blob.hasScript(scriptname()))
+			return;
+		CShape@ shape = blob.getShape();
+		if(blob.get_bool("ghostliketogglecoll") && shape !is null)
+			shape.getConsts().mapCollisions = true;
+		blob.RemoveScript(scriptname());
+		//removeFxLowGrav(blob);
+	}
+
 }

--- a/Entities/StatusFx/FxGhostlikeTick.as
+++ b/Entities/StatusFx/FxGhostlikeTick.as
@@ -4,7 +4,7 @@
 void onTick(CBlob@ this)
 {
 	if(this.get_u16("fxghostliketime") == 0)
-		removeFxGhostlike(this);
+		FxGhostlike::remove(this);
 	else
 		this.add_u16("fxghostliketime", -1);
 		

--- a/Entities/StatusFx/FxHoly.as
+++ b/Entities/StatusFx/FxHoly.as
@@ -1,34 +1,39 @@
 //HOLY effect
-string hoscriptname = "FxHolyTick";
+
+namespace FxHoly {
+
+	shared string scriptname() {return "FxHolyTick";}
 
 
-void applyFxHoly(CBlob@ blob, int time, int power)
-{
-	if(!blob.hasScript("FxHook"))
-		return;
-	if(blob.get_u16("fxholytime") > 0)
+	shared void apply(CBlob@ blob, int time, int power)
 	{
-		if(blob.get_u16("fxholypower") <= power)
+		if(!blob.hasScript("FxHook"))
+			return;
+		if(blob.get_u16("fxholytime") > 0)
+		{
+			if(blob.get_u16("fxholypower") <= power)
+			{
+				blob.set_u16("fxholytime", time);
+				blob.set_u16("fxholypower", power);
+			}
+		}
+		else
 		{
 			blob.set_u16("fxholytime", time);
 			blob.set_u16("fxholypower", power);
+			blob.AddScript(scriptname());
+			CSprite@ sprite = blob.getSprite();
+			if(sprite !is null)
+				sprite.AddScript(scriptname());
 		}
 	}
-	else
+
+	void remove(CBlob@ blob)
 	{
-		blob.set_u16("fxholytime", time);
-		blob.set_u16("fxholypower", power);
-		blob.AddScript(hoscriptname);
+		blob.RemoveScript(scriptname());
 		CSprite@ sprite = blob.getSprite();
 		if(sprite !is null)
-			sprite.AddScript(hoscriptname);
+			sprite.RemoveScript(scriptname());
 	}
-}
 
-void removeFxHoly(CBlob@ blob)
-{
-	blob.RemoveScript(hoscriptname);
-	CSprite@ sprite = blob.getSprite();
-	if(sprite !is null)
-		sprite.RemoveScript(hoscriptname);
 }

--- a/Entities/StatusFx/FxHolyTick.as
+++ b/Entities/StatusFx/FxHolyTick.as
@@ -14,7 +14,7 @@ void onTick(CBlob@ this)
 {
 	this.add_u16("fxholytime", -1);
 	if(this.get_u16("fxholytime") == 0)
-		removeFxHoly(this);
+		FxHoly::remove(this);
 
 	
 	float movemult = 10.0 / (10.0 + float(this.get_u16("fxholypower")));

--- a/Entities/StatusFx/FxHook.as
+++ b/Entities/StatusFx/FxHook.as
@@ -25,7 +25,7 @@ void onTick(CBlob@ this)
 	{
 		this.add_u16("fxdamagereducetime", -1);
 		if(this.get_u16("fxdamagereducetime") == 0)
-			removeFxDamageReduce(this);
+			FxDamageReduce::remove(this);
 	}
 	
 	//FxCorrupt
@@ -33,7 +33,7 @@ void onTick(CBlob@ this)
 	{
 		this.add_u16("fxcorrupttime", -1);
 		if(this.get_u16("fxcorrupttime") == 0)
-			removeFxCorrupt(this);
+			FxCorrupt::remove(this);
 	}
 	
 	//FxPure
@@ -41,7 +41,7 @@ void onTick(CBlob@ this)
 	{
 		this.add_u16("fxpuretime", -1);
 		if(this.get_u16("fxpuretime") == 0)
-			removeFxPure(this);
+			FxPure::remove(this);
 	}
 }
 

--- a/Entities/StatusFx/FxLightFall.as
+++ b/Entities/StatusFx/FxLightFall.as
@@ -1,35 +1,39 @@
 //Light Fall effect
 //Just handled in FallDamage.as
 
-string lfscriptname = "FxLightFallTick";
+namespace FxLightFall {	
 
-void applyFxLightFall(CBlob@ blob, int time, int power)
-{
-	if(!blob.hasScript("FxHook"))
-		return;
-	if(blob.get_u16("fxlightfalltime") > 0)
+	shared string scriptname() {return "FxLightFallTick";}
+
+	shared void apply(CBlob@ blob, int time, int power)
 	{
-		if(blob.get_u16("fxlightfallpower") <= power)
+		if(!blob.hasScript("FxHook"))
+			return;
+		if(blob.get_u16("fxlightfalltime") > 0)
+		{
+			if(blob.get_u16("fxlightfallpower") <= power)
+			{
+				blob.set_u16("fxlightfalltime", time);
+				blob.set_u16("fxlightfallpower", power);
+			}
+		}
+		else
 		{
 			blob.set_u16("fxlightfalltime", time);
 			blob.set_u16("fxlightfallpower", power);
+			blob.AddScript(scriptname());
+			CSprite@ sprite = blob.getSprite();
+			if(sprite !is null)
+				sprite.AddScript(scriptname());
 		}
 	}
-	else
+
+	void remove(CBlob@ blob)
 	{
-		blob.set_u16("fxlightfalltime", time);
-		blob.set_u16("fxlightfallpower", power);
-		blob.AddScript(lfscriptname);
+		blob.RemoveScript(scriptname());
 		CSprite@ sprite = blob.getSprite();
 		if(sprite !is null)
-			sprite.AddScript(lfscriptname);
+			sprite.RemoveScript(scriptname());
 	}
-}
 
-void removeFxLightFall(CBlob@ blob)
-{
-	blob.RemoveScript(lfscriptname);
-	CSprite@ sprite = blob.getSprite();
-	if(sprite !is null)
-		sprite.RemoveScript(lfscriptname);
 }

--- a/Entities/StatusFx/FxLightFallTick.as
+++ b/Entities/StatusFx/FxLightFallTick.as
@@ -5,7 +5,7 @@
 void onTick(CBlob@ this)
 {
 	if(this.get_u16("fxlightfalltime") == 0)
-		removeFxLightFall(this);
+		FxLightFall::remove(this);
 	else
 		this.add_u16("fxlightfalltime", -1);
 }
@@ -14,7 +14,7 @@ void onRender(CSprite@ this)
 {
 	CBlob@ blob = this.getBlob();
 	if(blob.get_u16("fxlightfalltime") != 0)
-	//	removeFxCorrupt(blob);
+	//	FxCorrupt::remove(blob);
 	//else
 		lightFallFxRender(blob);
 }

--- a/Entities/StatusFx/FxLowGrav.as
+++ b/Entities/StatusFx/FxLowGrav.as
@@ -1,62 +1,65 @@
 //Gravity Status effect
+namespace FxLowGrav {
 
-void applyFxLowGrav(CBlob@ blob, int time, int power)
-{
-	CShape@ shape = blob.getShape();
-	CMovement@ movement = blob.getMovement();
-	if(!blob.exists("basegrav") && shape !is null)
-		blob.set_f32("basegrav", shape.getGravityScale());
-	if(blob.hasTag("fxgravactive"))
+	shared void apply(CBlob@ blob, int time, int power)
 	{
-		if(blob.get_u16("fxgravpower") <= power)
+		CShape@ shape = blob.getShape();
+		CMovement@ movement = blob.getMovement();
+		if(!blob.exists("basegrav") && shape !is null)
+			blob.set_f32("basegrav", shape.getGravityScale());
+		if(blob.hasTag("fxgravactive"))
 		{
-			removeFxLowGrav(blob, true);
+			if(blob.get_u16("fxgravpower") <= power)
+			{
+				remove(blob, true);
+				blob.Tag("fxgravactive");
+				blob.set_u16("fxgravtime", time);
+				blob.set_u16("fxgravpower", power);
+				
+				//if(movement !is null && movement.hasScript("RunnerMovement"))
+					blob.set_f32("basegrav", blob.get_f32("basegrav") / (2.0 * float(power)));
+					shape.SetGravityScale(blob.get_f32("basegrav"));
+				//blob.AddScript("FxLowGravTick");
+			}
+		}
+		else
+		{
 			blob.Tag("fxgravactive");
 			blob.set_u16("fxgravtime", time);
 			blob.set_u16("fxgravpower", power);
-			
 			//if(movement !is null && movement.hasScript("RunnerMovement"))
 				blob.set_f32("basegrav", blob.get_f32("basegrav") / (2.0 * float(power)));
 				shape.SetGravityScale(blob.get_f32("basegrav"));
-			//blob.AddScript("FxLowGravTick");
+			blob.AddScript("FxLowGravTick");
+			CSprite@ sprite = blob.getSprite();
+			if(sprite !is null)
+				sprite.AddScript("FxLowGravTick");
 		}
 	}
-	else
+
+	void refresh(CBlob@ blob)
 	{
-		blob.Tag("fxgravactive");
-		blob.set_u16("fxgravtime", time);
-		blob.set_u16("fxgravpower", power);
+		CShape@ shape = blob.getShape();
+		shape.SetGravityScale(shape.getGravityScale() / (2.0 * float(blob.get_u16("fxgravpower"))));
+	}
+
+	shared void remove(CBlob@ blob, bool calconly = false)
+	{
+		if(!blob.hasTag("fxgravactive"))
+			return;
+		CShape@ shape = blob.getShape();
+		CMovement@ movement = blob.getMovement();
+		
+		blob.Untag("fxgravactive");
+		
 		//if(movement !is null && movement.hasScript("RunnerMovement"))
-			blob.set_f32("basegrav", blob.get_f32("basegrav") / (2.0 * float(power)));
-			shape.SetGravityScale(blob.get_f32("basegrav"));
-		blob.AddScript("FxLowGravTick");
+		blob.set_f32("basegrav", blob.get_f32("basegrav") * (2.0 * float(blob.get_u16("fxgravpower"))));
+		shape.SetGravityScale(blob.get_f32("basegrav"));
+		if(!calconly)
+			blob.RemoveScript("FxLowGravTick");
 		CSprite@ sprite = blob.getSprite();
-		if(sprite !is null)
+		if(sprite !is null && !calconly)
 			sprite.AddScript("FxLowGravTick");
 	}
-}
 
-void refreshFxLowGrav(CBlob@ blob)
-{
-	CShape@ shape = blob.getShape();
-	shape.SetGravityScale(shape.getGravityScale() / (2.0 * float(blob.get_u16("fxgravpower"))));
-}
-
-void removeFxLowGrav(CBlob@ blob, bool calconly = false)
-{
-	if(!blob.hasTag("fxgravactive"))
-		return;
-	CShape@ shape = blob.getShape();
-	CMovement@ movement = blob.getMovement();
-	
-	blob.Untag("fxgravactive");
-	
-	//if(movement !is null && movement.hasScript("RunnerMovement"))
-	blob.set_f32("basegrav", blob.get_f32("basegrav") * (2.0 * float(blob.get_u16("fxgravpower"))));
-	shape.SetGravityScale(blob.get_f32("basegrav"));
-	if(!calconly)
-		blob.RemoveScript("FxLowGravTick");
-	CSprite@ sprite = blob.getSprite();
-	if(sprite !is null && !calconly)
-		sprite.AddScript("FxLowGravTick");
 }

--- a/Entities/StatusFx/FxLowGravTick.as
+++ b/Entities/StatusFx/FxLowGravTick.as
@@ -5,7 +5,7 @@
 void onTick(CBlob@ this)
 {
 	if(this.get_u16("fxgravtime") == 0)
-		removeFxLowGrav(this);
+		FxLowGrav::remove(this);
 	else
 		this.add_u16("fxgravtime", -1);
 }
@@ -14,7 +14,7 @@ void onRender(CSprite@ this)
 {
 	CBlob@ blob = this.getBlob();
 	if(blob.get_u16("fxgravtime") != 0)
-		//removeFxDamageReduce(blob);
+		//FxDamageReduce::remove(blob);
 	//else
 		lowGravRender(blob);
 }

--- a/Entities/StatusFx/FxPureTick.as
+++ b/Entities/StatusFx/FxPureTick.as
@@ -6,7 +6,7 @@ void onRender(CSprite@ this)
 {
 	CBlob@ blob = this.getBlob();
 	if(blob.get_u16("fxpuretime") != 0)
-	//	removeFxCorrupt(blob);
+	//	FxCorrupt::remove(blob);
 	//else
 		pureFxRender(blob);
 }

--- a/Entities/StatusFx/FxRegen.as
+++ b/Entities/StatusFx/FxRegen.as
@@ -2,43 +2,47 @@
 
 //#include "FxRegenTick.as";
 
-const string scriptnameregen = "FxRegenTick";
+namespace FxRegen {
 
-void applyFxRegen(CBlob@ blob, int time, int power)
-{
-	if(blob.hasScript(scriptnameregen))
+	shared string scriptname() {return "FxRegenTick";}
+
+	shared void apply(CBlob@ blob, int time, int power)
 	{
-		if(blob.get_u16("fxregenpower") <= power)
+		if(blob.hasScript(scriptname()))
+		{
+			if(blob.get_u16("fxregenpower") <= power)
+			{
+				blob.set_u16("fxregentime", time);
+				blob.set_u16("fxregenpower", power);
+				//applyFxLowGrav(blob, time + 100, 100);
+			}
+		}
+		else
 		{
 			blob.set_u16("fxregentime", time);
 			blob.set_u16("fxregenpower", power);
 			//applyFxLowGrav(blob, time + 100, 100);
+			//if(blob.get_bool("ghostliketogglecoll"))
+				//shape.getConsts().mapCollisions = false;
+			blob.AddScript(scriptname());
+			CSprite@ sprite = blob.getSprite();
+			if(sprite !is null)
+				sprite.AddScript(scriptname());
 		}
 	}
-	else
+
+	void remove(CBlob@ blob)
 	{
-		blob.set_u16("fxregentime", time);
-		blob.set_u16("fxregenpower", power);
-		//applyFxLowGrav(blob, time + 100, 100);
-		//if(blob.get_bool("ghostliketogglecoll"))
-			//shape.getConsts().mapCollisions = false;
-		blob.AddScript(scriptnameregen);
+		if(!blob.hasScript(scriptname()))
+			return;
+		//CShape@ shape = blob.getShape();
+		//if(blob.get_bool("ghostliketogglecoll") && shape !is null)
+			//shape.getConsts().mapCollisions = true;
+		blob.RemoveScript(scriptname());
 		CSprite@ sprite = blob.getSprite();
 		if(sprite !is null)
-			sprite.AddScript(scriptnameregen);
+			sprite.RemoveScript(scriptname());
+		//removeFxLowGrav(blob);
 	}
-}
 
-void removeFxRegen(CBlob@ blob)
-{
-	if(!blob.hasScript(scriptnameregen))
-		return;
-	//CShape@ shape = blob.getShape();
-	//if(blob.get_bool("ghostliketogglecoll") && shape !is null)
-		//shape.getConsts().mapCollisions = true;
-	blob.RemoveScript(scriptnameregen);
-	CSprite@ sprite = blob.getSprite();
-	if(sprite !is null)
-		sprite.RemoveScript(scriptnameregen);
-	//removeFxLowGrav(blob);
 }

--- a/Entities/StatusFx/FxRegenTick.as
+++ b/Entities/StatusFx/FxRegenTick.as
@@ -5,7 +5,7 @@
 void onTick(CBlob@ this)
 {
 	if(this.get_u16("fxregentime") == 0)
-		removeFxRegen(this);
+		FxRegen::remove(this);
 	else
 		this.add_u16("fxregentime", -1);
 	
@@ -19,7 +19,7 @@ void onRender(CSprite@ this)
 {
 	CBlob@ blob = this.getBlob();
 	//if(blob.get_u16("fxdamagereducetime") == 0)
-	//	removeFxDamageReduce(blob);
+	//	FxDamageReduce::remove(blob);
 	//else
 		regenRender(blob);
 }

--- a/Entities/StatusFx/FxUnholy.as
+++ b/Entities/StatusFx/FxUnholy.as
@@ -1,34 +1,37 @@
 //UNHOLY effect
-string uhscriptname = "FxUnholyTick";
 
+namespace FxUnholy {
 
-void applyFxUnholy(CBlob@ blob, int time, int power)
-{
-	if(!blob.hasScript("FxHook"))
-		return;
-	if(blob.get_u16("fxunholytime") > 0)
+	shared string scriptname() {return "FxUnholyTick";}
+	shared void apply(CBlob@ blob, int time, int power)
 	{
-		if(blob.get_u16("fxunholypower") <= power)
+		if(!blob.hasScript("FxHook"))
+			return;
+		if(blob.get_u16("fxunholytime") > 0)
+		{
+			if(blob.get_u16("fxunholypower") <= power)
+			{
+				blob.set_u16("fxunholytime", time);
+				blob.set_u16("fxunholypower", power);
+			}
+		}
+		else
 		{
 			blob.set_u16("fxunholytime", time);
 			blob.set_u16("fxunholypower", power);
+			blob.AddScript(scriptname());
+			CSprite@ sprite = blob.getSprite();
+			if(sprite !is null)
+				sprite.AddScript(scriptname());
 		}
 	}
-	else
+
+	void remove(CBlob@ blob)
 	{
-		blob.set_u16("fxunholytime", time);
-		blob.set_u16("fxunholypower", power);
-		blob.AddScript(uhscriptname);
+		blob.RemoveScript(scriptname());
 		CSprite@ sprite = blob.getSprite();
 		if(sprite !is null)
-			sprite.AddScript(uhscriptname);
+			sprite.RemoveScript(scriptname());
 	}
-}
 
-void removeFxUnholy(CBlob@ blob)
-{
-	blob.RemoveScript(uhscriptname);
-	CSprite@ sprite = blob.getSprite();
-	if(sprite !is null)
-		sprite.RemoveScript(uhscriptname);
 }

--- a/Entities/StatusFx/FxUnholyTick.as
+++ b/Entities/StatusFx/FxUnholyTick.as
@@ -14,7 +14,7 @@ void onTick(CBlob@ this)
 {
 	this.add_u16("fxunholytime", -1);
 	if(this.get_u16("fxunholytime") == 0)
-		removeFxUnholy(this);
+		FxUnholy::remove(this);
 
 	
 	float movemult = (10.0 + float(this.get_u16("fxunholypower"))) / 10.0;

--- a/Legacy/ShieldCommon.as
+++ b/Legacy/ShieldCommon.as
@@ -1,0 +1,147 @@
+
+//shield common functions
+
+shared class ShieldVars
+{
+	Vec2f direction;
+	f32 angleTolerance;
+	f32 breakingForce;
+	f32 stopBlockingForce;
+	bool enabled;
+	bool forcedDown;
+};
+
+//put this in oninit
+void addShieldVars(CBlob@ this, f32 shieldAngleSize = 30.0f, f32 breakForce = 1.0f, f32 stopBlockingForce = 5.0f)
+{
+	ShieldVars vars;
+	vars.direction = Vec2f(0, 0);
+	vars.angleTolerance = shieldAngleSize / 2;
+	vars.breakingForce = breakForce;
+	vars.stopBlockingForce = stopBlockingForce;
+	vars.enabled = false;
+	vars.forcedDown = false;
+	this.set("shield vars", vars);
+}
+
+shared ShieldVars@ getShieldVars(CBlob@ this)
+{
+	ShieldVars@ vars;
+	this.get("shield vars", @vars);
+	return vars;
+}
+
+void setShieldDirection(CBlob@ this, Vec2f direction)
+{
+	ShieldVars@ vars = getShieldVars(this);
+	if (vars is null) { return; }
+	vars.direction = direction;
+}
+
+void setShieldAngle(CBlob@ this, float shieldAngleSize)
+{
+	ShieldVars@ vars = getShieldVars(this);
+	if (vars is null) { return; }
+	vars.angleTolerance = shieldAngleSize / 2;
+}
+
+void setShieldEnabled(CBlob@ this, bool enabled)
+{
+	ShieldVars@ vars = getShieldVars(this);
+
+	if (vars is null) { return; }
+
+	if (!vars.forcedDown)
+	{
+		vars.enabled = enabled;
+
+		if (enabled)
+		{
+			this.Tag("shielded");
+		}
+		else
+		{
+			this.Untag("shielded");
+		}
+	}
+	else
+	{
+		vars.enabled = false;
+		this.Untag("shielded");
+	}
+}
+
+void knockShieldDown(CBlob@ this)
+{
+	ShieldVars@ vars = getShieldVars(this);
+
+	if (vars is null) { return; }
+
+	vars.forcedDown = true;
+	this.Untag("shielded");
+}
+
+void resetShieldKnockdown(CBlob@ this)
+{
+	ShieldVars@ vars = getShieldVars(this);
+
+	if (vars is null) { return; }
+
+	vars.forcedDown = false;
+}
+
+bool canRaiseShield(CBlob@ this)
+{
+	ShieldVars@ vars = getShieldVars(this);
+
+	if (vars is null) { return false; }
+
+	return !vars.forcedDown;
+}
+
+bool isShieldEnabled(CBlob@ this)
+{
+	ShieldVars@ vars = getShieldVars(this);
+
+	if (vars is null) { return false; }
+
+	return vars.enabled;
+}
+
+shared bool blockAttack(CBlob@ this, Vec2f direction, f32 damage)
+{
+	if (this.hasTag("dead")) return false;
+
+	ShieldVars@ vars = getShieldVars(this);
+
+	if (vars is null) { return false; }
+
+	//shield isn't up
+	if (!vars.enabled) { return false; }
+
+	//zero direction = bypass shield
+	if (direction.LengthSquared() < 0.001f) return false;
+
+	//shield isn't blocking/strong enough
+	f32 angle = Maths::Abs(vars.direction.AngleWith(direction));
+	f32 angle_difference = 180.0f - angle;
+	/*print( " SHIELD DEBUG: " );
+	print( "               damage: "+damage );
+	print( "            break dam: "+vars.breakingForce );
+	print( "                angle: "+angle );
+	print( " angle_diff(compared): "+angle_difference );
+	print( "            tolerance: "+vars.angleTolerance );
+	print( "     attack direction: "+direction.x+", "+direction.y );
+	print( "     shield direction: "+vars.direction.x+", "+vars.direction.y );*/
+	return ((angle_difference) < vars.angleTolerance && damage < vars.breakingForce);
+}
+
+bool exceedsShieldBreakForce(CBlob@ this, f32 damage)
+{
+	ShieldVars@ vars = getShieldVars(this);
+
+	if (vars is null) { return false; }
+
+	//print("dmg " + damage + "break " + vars.breakingForce);
+	return damage >= vars.breakingForce;
+}

--- a/Rules/SORRN/TileInteractions.as
+++ b/Rules/SORRN/TileInteractions.as
@@ -2,7 +2,7 @@
 
 #include "CHitters.as";
 
-void corruptTile(Vec2f tilepos, CMap@ map)
+shared void corruptTile(Vec2f tilepos, CMap@ map)
 {
 	if(isServer())
 	{
@@ -110,7 +110,7 @@ void corruptTick(Vec2f tilepos, CMap@ map)
 	}
 }
 
-bool purifyTile(Vec2f tilepos, CMap@ map)
+shared bool purifyTile(Vec2f tilepos, CMap@ map)
 {
 	//if(isServer())
 	{

--- a/Rules/Scripts/ExtraChatCommands.as
+++ b/Rules/Scripts/ExtraChatCommands.as
@@ -59,6 +59,7 @@ class Vial :CommandBase
 
 	bool CommandCode(CRules@ this, string[]@ tokens, CPlayer@ player, CBlob@ blob, Vec2f pos, int team, CPlayer@ target_player, CBlob@ target_blob) override
     {
+        array<CElementSetup> @elementlist = @getElementList();
 		int id = -1;
 		id = elementIdFromName(tokens[1]);
 


### PR DESCRIPTION
Pretty much what title says. Ability objects (ability manager) are exchanged between scripts, and so they should be shared (to ensure there's not UB). Entire purpose of this PR is to make ability manager class shared, and all these changed are required to do so (since shared classes can only interact with shared entities).
Somewhere along the way I rewrote effects code to be kinda consistent (each effect has it's own namespace, and all functions are named same way for all effects ([namespace]::apply, [namespace]::remove etc).

The thing is, I thought that'll resolve some issues, but it didn't. And it seems abilities kinda work anyway (even without this change), so idk if that should be merged or not.